### PR TITLE
fix: dont hide manual date input on update

### DIFF
--- a/frontend/components/ActivityDialog.vue
+++ b/frontend/components/ActivityDialog.vue
@@ -587,7 +587,7 @@ function setSelectedDate(date: Date) {
                     </div>
                 </TabPanel>
                 <TabPanel
-                    v-if="!onlyShowRef || create"
+                    v-if="!onlyShowRef || create || updateRef"
                     :header="t('activity.manual.header')"
                     :pt="{
                         headerAction: () => ({


### PR DESCRIPTION
https://journeyplanner2.atlassian.net/browse/JP-190

manual date input ist nach dem zweiten mal bearbeiten verschwunden, sollte das fixen