### PR TITLE
fix: stop upload component from overlapping member sidebar

### DIFF
--- a/frontend/components/form/Upload.vue
+++ b/frontend/components/form/Upload.vue
@@ -80,7 +80,7 @@ const uppy = new Uppy({
 
 <style>
 .uppy-Root {
-    @apply font-nunito !important;
+    @apply z-10 font-nunito !important;
 }
 
 .uppy-Dashboard .uppy-Dashboard-inner {


### PR DESCRIPTION
wollte eig [das](https://journeyplanner2.atlassian.net/browse/JP-192 ) fixen, ist aber nicht mehr aufgetreten oder kp, hab aber gesehen das wenn ein file geadded wurde im upload bereich, das dann teile davon die sidebar überlappt haben