### PR TITLE
JP-199: fix: Fix media upload and gallery

### DIFF
--- a/backend/app/Http/Controllers/Journey/MediaController.php
+++ b/backend/app/Http/Controllers/Journey/MediaController.php
@@ -16,8 +16,6 @@ class MediaController extends Controller
      */
     public function index(Journey $journey): JsonResponse
     {
-        Gate::authorize("view", [$journey, false]);
-
         $media = $journey->media->map(function ($media) {
             return [
                 "id" => $media->id,
@@ -42,12 +40,10 @@ class MediaController extends Controller
     /**
      * Display the specified media.
      */
-    public function show(Request $request, Journey $journey, Media $media)
+    public function show(Request $request, Journey $journey, string $media)
     {
-        Gate::authorize("show", [$journey, false]);
-
+        $media = Media::findOrFail($media);
         if ($request->has("thumbnail")) {
-            $media = Media::findOrFail($media);
             $thumbnailPath = $media->getThumbnailPath();
             if (file_exists($thumbnailPath)) {
                 return response()->file($thumbnailPath);
@@ -56,7 +52,6 @@ class MediaController extends Controller
             }
         }
 
-        $media = Media::findOrFail($media);
         $path = $media->getMediaPath();
         if (file_exists($path)) {
             return response()->file($media->getMediaPath());

--- a/backend/app/Http/Controllers/Journey/MediaController.php
+++ b/backend/app/Http/Controllers/Journey/MediaController.php
@@ -16,6 +16,8 @@ class MediaController extends Controller
      */
     public function index(Journey $journey): JsonResponse
     {
+        Gate::authorize("view", [$journey, false]);
+
         $media = $journey->media->map(function ($media) {
             return [
                 "id" => $media->id,
@@ -40,9 +42,9 @@ class MediaController extends Controller
     /**
      * Display the specified media.
      */
-    public function show(Request $request, Journey $journey, string $media)
+    //public function show(Request $request, Journey $journey, string $media)
+    public function show(Request $request, Journey $journey, Media $media)
     {
-        $media = Media::findOrFail($media);
         if ($request->has("thumbnail")) {
             $thumbnailPath = $media->getThumbnailPath();
             if (file_exists($thumbnailPath)) {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -78,9 +78,10 @@ Route::post("upload", [UploadController::class, "upload"])->middleware([
     "auth:sanctum",
 ]);
 
-Route::apiResource("journey/{journey}/media", MediaController::class)
-    ->middleware("auth:sanctum")
-    ->only("index", "show");
+Route::apiResource("journey/{journey}/media", MediaController::class)->only(
+    "index",
+    "show"
+);
 
 Route::get("journey/{journey}/weather", [
     JourneyController::class,

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -78,10 +78,12 @@ Route::post("upload", [UploadController::class, "upload"])->middleware([
     "auth:sanctum",
 ]);
 
-Route::apiResource("journey/{journey}/media", MediaController::class)->only(
+Route::get("journey/{journey}/media", [
+    MediaController::class,
     "index",
-    "show"
-);
+])->middleware(["auth:sanctum"]);
+
+Route::get("journey/{journey}/media/{media}", [MediaController::class, "show"]);
 
 Route::get("journey/{journey}/weather", [
     JourneyController::class,

--- a/docker/tusd/.gitignore
+++ b/docker/tusd/.gitignore
@@ -1,3 +1,4 @@
 *
 !.gitignore
 !tusd.ps1
+!tusd.sh

--- a/docker/tusd/tusd.sh
+++ b/docker/tusd/tusd.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+downloadUrl="https://github.com/tus/tusd/releases/latest/download/tusd_linux_amd64.tar.gz"
+outputPath="./tusd.zip"
+executablePath="./tusd_linux_amd64/tusd"
+
+if [ ! -f "$executablePath" ]; then
+    curl -L -o "$outputPath" "$downloadUrl"
+    tar -xvf "$outputPath"
+    rm "$outputPath"
+fi
+
+# Execute tusd
+./tusd_linux_amd64/tusd -hooks-http http://localhost:8000/api/upload -hooks-http-forward-headers Authorization -hooks-enabled-events pre-create,post-finish


### PR DESCRIPTION
Works locally, server may need chown to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a shell script to automate `tusd` server download and execution.

- **Changes**
  - Updated media route configuration to allow unauthenticated access to the media display action.
  - Modified media controller method signature to accept a media identifier as a string.

- **Chores**
  - Updated `.gitignore` to track specific files in the `docker/tusd` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->