### PR TITLE
JP-205: fix: darkmode colors for header links now match with the colo…

### DIFF
--- a/frontend/pages/about.vue
+++ b/frontend/pages/about.vue
@@ -126,7 +126,7 @@ const changeColorMode = () => {
                 </NuxtLink>
                 <nav class="flex flex-row items-center gap-4">
                     <ul
-                        class="hidden flex-row items-center gap-2 text-natural-500 dark:text-natural-600 sm:flex"
+                        class="hidden flex-row items-center gap-2 text-natural-500 dark:text-natural-400 sm:flex"
                     >
                         <li>
                             <button


### PR DESCRIPTION
…rs on the startpage

closes #560 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the dark mode text color for list elements on the About page for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->