### PR TITLE
JP-210: fix: prevent calender editing when journey member

### DIFF
--- a/frontend/components/journey/id/JourneyCalendar.vue
+++ b/frontend/components/journey/id/JourneyCalendar.vue
@@ -321,6 +321,7 @@ const calendarOptions = reactive({
     eventDrop: initializeDrop,
     eventResize: editDrop,
     eventClick: showData,
+    editable: props.currentUserRole === 1,
     eventBackgroundColor: bg,
     eventBorderColor: border,
     eventTextColor: text,
@@ -330,7 +331,6 @@ const calendarOptions = reactive({
     droppable: true,
     initialDate: start,
     firstDay: 1,
-    editable: true,
     views: {
         fullweek: {
             type: "timeGrid",
@@ -805,6 +805,7 @@ function call(editType: string) {
 .fc-timegrid-event.fc-event-mirror,
 .fc-timegrid-more-link {
     box-shadow: none;
+    cursor: pointer;
 }
 
 .dark .fc-theme-standard td,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar event editing now adapts to the current user's role, ensuring that only authorized users can modify events.
- **Style**
  - Enhanced the visual indicators for interactive calendar elements by updating the cursor style to better signal clickable areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->