### PR TITLE
fix: Use HTTP2 in a non deprecated way

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -27,7 +27,8 @@ http {
     gzip on;
 
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
 
         server_name journeyplanner.io;
 
@@ -60,7 +61,8 @@ http {
     }
 
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
 
         server_name api.journeyplanner.io;
 
@@ -100,7 +102,8 @@ http {
     }
 
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
 
         server_name upload.journeyplanner.io;
 
@@ -126,7 +129,8 @@ http {
     }
 
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name www.journeyplanner.io;
 
         ssl_certificate /etc/nginx/certs/journeyplanner.io.pem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated network configuration to enhance secure HTTP/2 support by separating protocol settings. This improves how secure connections are managed without altering the SSL protection, contributing to a more robust and maintainable system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->