### PR TITLE
Update Dockerfile to install Infisical CLI the new way

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,8 @@ COPY package*.json ./
 RUN npm ci
 
 RUN apt-get update && apt-get install -y bash curl && curl -1sLf \
-'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash \
+'https://artifacts-cli.infisical.com/setup.deb.sh' \
+| bash \
 && apt-get update && apt-get install -y infisical
 
 COPY --link . . 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend build to use a new source for the secrets CLI installation, improving reliability of environment setup.

* **Build**
  * Minor adjustment to the installation command formatting for better readability and maintainability during image builds.

* **Notes**
  * No user-facing functionality changes.
  * Application behavior and performance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->