### PR TITLE
Upgrade Jenkins Docker image to lts-jdk21

### DIFF
--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts-jdk17
+FROM jenkins/jenkins:lts-jdk21
 USER root
 RUN apt-get update && apt-get install -y lsb-release
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Jenkins base image to the latest LTS with JDK 21, improving security, stability, and long-term support.
  * Aligns build environment with modern Java runtime for better compatibility with newer plugins and tools.
  * No changes to application features or user workflows; pipelines should continue to run as before.
  * If custom build steps rely on JDK 17 specifics, verify compatibility and update configurations as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->