### PR TITLE
remove vue-mapbox

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,6 @@
                 "@nuxt/image": "^1.11.0",
                 "@nuxtjs/seo": "^3.1.0",
                 "@pinia/nuxt": "^0.11.2",
-                "@studiometa/vue-mapbox-gl": "^2.7.2",
                 "@tolgee/vue": "^6.2.7",
                 "@uppy/core": "^5.0.1",
                 "@uppy/dashboard": "^5.0.1",
@@ -79,19 +78,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@antfu/install-pkg": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
@@ -105,19 +91,12 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-            "license": "MIT"
-        },
         "node_modules/@apidevtools/json-schema-ref-parser": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.1.1.tgz",
-            "integrity": "sha512-uGF1YGOzzD50L7HLNWclXmsEhQflw8/zZHIz0/AzkJrKL5r9PceUipZxR/cp/8veTk4TVfdDJLyIwXLjaP5ePg==",
+            "version": "14.2.1",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
+            "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
             "license": "MIT",
             "dependencies": {
-                "@types/json-schema": "^7.0.15",
                 "js-yaml": "^4.1.0"
             },
             "engines": {
@@ -125,47 +104,50 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/philsturgeon"
+            },
+            "peerDependencies": {
+                "@types/json-schema": "^7.0.15"
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-            "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-            "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.10",
-                "@babel/helper-compilation-targets": "^7.26.5",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.10",
-                "@babel/parser": "^7.26.10",
-                "@babel/template": "^7.26.9",
-                "@babel/traverse": "^7.26.10",
-                "@babel/types": "^7.26.10",
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.3",
+                "@babel/helper-compilation-targets": "^7.27.2",
+                "@babel/helper-module-transforms": "^7.28.3",
+                "@babel/helpers": "^7.28.4",
+                "@babel/parser": "^7.28.4",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -206,25 +188,25 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
-            "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.9"
+                "@babel/types": "^7.27.3"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-            "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.8",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -258,17 +240,17 @@
             "license": "ISC"
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
-            "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+            "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.9",
-                "@babel/helper-member-expression-to-functions": "^7.25.9",
-                "@babel/helper-optimise-call-expression": "^7.25.9",
-                "@babel/helper-replace-supers": "^7.26.5",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-                "@babel/traverse": "^7.27.0",
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/traverse": "^7.28.3",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -287,41 +269,50 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
-            "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+            "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.28.3"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -331,35 +322,35 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
-            "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.9"
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
-            "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.25.9",
-                "@babel/helper-optimise-call-expression": "^7.25.9",
-                "@babel/traverse": "^7.26.5"
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -369,13 +360,13 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
-            "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -400,34 +391,34 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.4"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -437,12 +428,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-            "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -452,12 +443,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -467,16 +458,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
-            "integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+            "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.9",
-                "@babel/helper-create-class-features-plugin": "^7.27.0",
-                "@babel/helper-plugin-utils": "^7.26.5",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-                "@babel/plugin-syntax-typescript": "^7.25.9"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -486,50 +477,41 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.27.0",
-                "@babel/parser": "^7.27.0",
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.3",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.4",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.4",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -585,26 +567,26 @@
             }
         },
         "node_modules/@date-fns/utc": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.0.tgz",
-            "integrity": "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+            "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
             "license": "MIT"
         },
         "node_modules/@emnapi/core": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-            "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.0.4",
+                "@emnapi/wasi-threads": "1.1.0",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+            "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -612,9 +594,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-            "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -638,9 +620,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
-            "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+            "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
             "cpu": [
                 "ppc64"
             ],
@@ -654,9 +636,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
-            "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+            "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
             "cpu": [
                 "arm"
             ],
@@ -670,9 +652,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
-            "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+            "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
             "cpu": [
                 "arm64"
             ],
@@ -686,9 +668,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
-            "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+            "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
             "cpu": [
                 "x64"
             ],
@@ -702,9 +684,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
-            "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+            "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
             "cpu": [
                 "arm64"
             ],
@@ -718,9 +700,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
-            "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+            "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
             "cpu": [
                 "x64"
             ],
@@ -734,9 +716,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
-            "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
             "cpu": [
                 "arm64"
             ],
@@ -750,9 +732,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
-            "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+            "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
             "cpu": [
                 "x64"
             ],
@@ -766,9 +748,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
-            "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+            "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
             "cpu": [
                 "arm"
             ],
@@ -782,9 +764,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
-            "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+            "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
             "cpu": [
                 "arm64"
             ],
@@ -798,9 +780,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
-            "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+            "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
             "cpu": [
                 "ia32"
             ],
@@ -814,9 +796,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
-            "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+            "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
             "cpu": [
                 "loong64"
             ],
@@ -830,9 +812,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
-            "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+            "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
             "cpu": [
                 "mips64el"
             ],
@@ -846,9 +828,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
-            "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+            "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
             "cpu": [
                 "ppc64"
             ],
@@ -862,9 +844,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
-            "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+            "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
             "cpu": [
                 "riscv64"
             ],
@@ -878,9 +860,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
-            "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+            "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
             "cpu": [
                 "s390x"
             ],
@@ -894,9 +876,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
-            "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+            "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
             "cpu": [
                 "x64"
             ],
@@ -910,9 +892,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
-            "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
             "cpu": [
                 "arm64"
             ],
@@ -926,9 +908,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
-            "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
             "cpu": [
                 "x64"
             ],
@@ -942,9 +924,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
-            "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+            "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
             "cpu": [
                 "arm64"
             ],
@@ -958,9 +940,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
-            "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+            "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
             "cpu": [
                 "x64"
             ],
@@ -974,9 +956,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
-            "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+            "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
             "cpu": [
                 "arm64"
             ],
@@ -990,9 +972,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
-            "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+            "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
             "cpu": [
                 "x64"
             ],
@@ -1006,9 +988,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
-            "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+            "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
             "cpu": [
                 "arm64"
             ],
@@ -1022,9 +1004,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
-            "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+            "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
             "cpu": [
                 "ia32"
             ],
@@ -1038,9 +1020,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
-            "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+            "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
             "cpu": [
                 "x64"
             ],
@@ -1185,31 +1167,6 @@
             },
             "peerDependencies": {
                 "eslint": "^8.50.0 || ^9.0.0"
-            }
-        },
-        "node_modules/@eslint/config-inspector/node_modules/ansis": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
-            "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@eslint/config-inspector/node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/@eslint/core": {
@@ -1359,51 +1316,51 @@
             }
         },
         "node_modules/@fullcalendar/core": {
-            "version": "6.1.17",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
-            "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.19.tgz",
+            "integrity": "sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==",
             "license": "MIT",
             "dependencies": {
                 "preact": "~10.12.1"
             }
         },
         "node_modules/@fullcalendar/daygrid": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
-            "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.19.tgz",
+            "integrity": "sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==",
             "license": "MIT",
             "peerDependencies": {
-                "@fullcalendar/core": "~6.1.15"
+                "@fullcalendar/core": "~6.1.19"
             }
         },
         "node_modules/@fullcalendar/interaction": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.15.tgz",
-            "integrity": "sha512-DOTSkofizM7QItjgu7W68TvKKvN9PSEEvDJceyMbQDvlXHa7pm/WAVtAc6xSDZ9xmB1QramYoWGLHkCYbTW1rQ==",
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.19.tgz",
+            "integrity": "sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==",
             "license": "MIT",
             "peerDependencies": {
-                "@fullcalendar/core": "~6.1.15"
+                "@fullcalendar/core": "~6.1.19"
             }
         },
         "node_modules/@fullcalendar/timegrid": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.15.tgz",
-            "integrity": "sha512-61ORr3A148RtxQ2FNG7JKvacyA/TEVZ7z6I+3E9Oeu3dqTf6M928bFcpehRTIK6zIA6Yifs7BeWHgOE9dFnpbw==",
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.19.tgz",
+            "integrity": "sha512-OuzpUueyO9wB5OZ8rs7TWIoqvu4v3yEqdDxZ2VcsMldCpYJRiOe7yHWKr4ap5Tb0fs7Rjbserc/b6Nt7ol6BRg==",
             "license": "MIT",
             "dependencies": {
-                "@fullcalendar/daygrid": "~6.1.15"
+                "@fullcalendar/daygrid": "~6.1.19"
             },
             "peerDependencies": {
-                "@fullcalendar/core": "~6.1.15"
+                "@fullcalendar/core": "~6.1.19"
             }
         },
         "node_modules/@fullcalendar/vue3": {
-            "version": "6.1.17",
-            "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-6.1.17.tgz",
-            "integrity": "sha512-0+qi/PK/xCkTQXh2CaeN2AkP+SvQTznPhwBXuIyrtsR0Ua8UpmGEXI+my3qQ6o003r8gPUY2e785ywIyhX2zCA==",
+            "version": "6.1.19",
+            "resolved": "https://registry.npmjs.org/@fullcalendar/vue3/-/vue3-6.1.19.tgz",
+            "integrity": "sha512-j5eUSxx0xIy3ADljo0f5B9PhjqXnCQ+7nUMPfsslc2eGVjp4F74YvY3dyd6OBbg13IvpsjowkjncGipYMQWmTA==",
             "license": "MIT",
             "peerDependencies": {
-                "@fullcalendar/core": "~6.1.17",
+                "@fullcalendar/core": "~6.1.19",
                 "vue": "^3.0.11"
             }
         },
@@ -1480,29 +1437,16 @@
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -1519,9 +1463,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-            "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -1532,9 +1476,9 @@
             }
         },
         "node_modules/@ioredis/commands": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-            "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+            "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
             "license": "MIT"
         },
         "node_modules/@isaacs/cliui": {
@@ -1636,9 +1580,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1652,9 +1596,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.30",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-            "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1736,16 +1680,16 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@mapbox/mapbox-sdk": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.1.tgz",
-            "integrity": "sha512-dyZrmg+UL/Gp5mGG3CDbcwGSUMYYrfbd9hdp0rcA3pHSf3A9eYoXO9nFiIk6SzBwBVMzHENJz84ZHdqM0MDncQ==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.2.tgz",
+            "integrity": "sha512-II8KrqOD+neL94bCakBQfYmNSD8A3MQHyxxtZ9Hy5nZQWFacocpj2PjPvQqgctmddWZQ9GS+WBgHPVamhuM9xA==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@mapbox/fusspot": "^0.4.0",
                 "@mapbox/parse-mapbox-token": "^0.2.0",
                 "@mapbox/polyline": "^1.0.0",
                 "eventemitter3": "^3.1.0",
-                "form-data": "^3.0.0",
+                "form-data": "^3.0.4",
                 "got": "^11.8.5",
                 "is-plain-obj": "^1.1.0",
                 "xtend": "^4.0.1"
@@ -1776,9 +1720,9 @@
             }
         },
         "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+            "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
@@ -1854,9 +1798,9 @@
             }
         },
         "node_modules/@mapbox/tiny-sdf": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-            "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+            "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
             "license": "BSD-2-Clause"
         },
         "node_modules/@mapbox/unitbezier": {
@@ -1886,36 +1830,15 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.5.tgz",
+            "integrity": "sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
-            }
-        },
-        "node_modules/@netlify/functions": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-3.0.4.tgz",
-            "integrity": "sha512-Ox8+ABI+nsLK+c4/oC5dpquXuEIjzfTlJrdQKgQijCsDQoje7inXFAtKDLvvaGvuvE+PVpMLwQcIUL6P9Ob1hQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@netlify/serverless-functions-api": "1.36.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@netlify/serverless-functions-api": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.36.0.tgz",
-            "integrity": "sha512-z6okREyK8in0486a22Oro0k+YsuyEjDXJt46FpgeOgXqKJ9ElM8QPll0iuLBkpbH33ENiNbIPLd1cuClRQnhiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
+                "@emnapi/core": "^1.5.0",
+                "@emnapi/runtime": "^1.5.0",
+                "@tybys/wasm-util": "^0.10.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1954,34 +1877,37 @@
             }
         },
         "node_modules/@nuxt/cli": {
-            "version": "3.23.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.23.1.tgz",
-            "integrity": "sha512-vwHicydSXkpQlrjSOHOMLx4rULMNke1tqT+B2rGkVX9RMWJu9jdvp6GqRWJfqeeLoFG0gYNr02pSp6ulxuwOMQ==",
+            "version": "3.28.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.28.0.tgz",
+            "integrity": "sha512-WQ751WxWLBIeH3TDFt/LWQ2znyAKxpR5+gpv80oerwnVQs4GKajAfR6dIgExXZkjaPUHEFv2lVD9vM+frbprzw==",
             "license": "MIT",
             "dependencies": {
-                "c12": "^3.0.2",
-                "chokidar": "^4.0.3",
+                "c12": "^3.2.0",
                 "citty": "^0.1.6",
                 "clipboardy": "^4.0.0",
+                "confbox": "^0.2.2",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
+                "exsolve": "^1.0.7",
                 "fuse.js": "^7.1.0",
+                "get-port-please": "^3.2.0",
                 "giget": "^2.0.0",
-                "h3": "^1.15.1",
+                "h3": "^1.15.4",
                 "httpxy": "^0.1.7",
-                "jiti": "^2.4.2",
+                "jiti": "^2.5.1",
                 "listhen": "^1.9.0",
-                "nypm": "^0.6.0",
+                "nypm": "^0.6.1",
                 "ofetch": "^1.4.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
                 "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.1.0",
+                "pkg-types": "^2.2.0",
                 "scule": "^1.3.0",
-                "semver": "^7.7.1",
-                "std-env": "^3.8.1",
-                "tinyexec": "^0.3.2",
-                "ufo": "^1.5.4"
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyexec": "^1.0.1",
+                "ufo": "^1.6.1",
+                "youch": "^4.1.0-beta.11"
             },
             "bin": {
                 "nuxi": "bin/nuxi.mjs",
@@ -1993,6 +1919,12 @@
                 "node": "^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@nuxt/cli/node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "license": "MIT"
+        },
         "node_modules/@nuxt/devalue": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
@@ -2000,43 +1932,43 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/devtools": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-2.3.1.tgz",
-            "integrity": "sha512-SA/ShgsB/E1DMAC7BZI6sP00djvOXfhrwaqdpb1rNNOqNJ/JX1oc+LVNtKTPAzxUouDsv5sAeEVdPT5enync2g==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-2.6.3.tgz",
+            "integrity": "sha512-n+8we7pr0tNl6w+KfbFDXZsYpWIYL4vG/daIdRF66lQ6fLyQy/CcxDAx8+JNu3Ew96RjuBtWRSbCCv454L5p0Q==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "2.3.1",
-                "@nuxt/devtools-wizard": "2.3.1",
-                "@nuxt/kit": "^3.16.1",
-                "@vue/devtools-core": "^7.7.2",
-                "@vue/devtools-kit": "^7.7.2",
-                "birpc": "^2.2.0",
+                "@nuxt/devtools-kit": "2.6.3",
+                "@nuxt/devtools-wizard": "2.6.3",
+                "@nuxt/kit": "^3.18.1",
+                "@vue/devtools-core": "^7.7.7",
+                "@vue/devtools-kit": "^7.7.7",
+                "birpc": "^2.5.0",
                 "consola": "^3.4.2",
-                "destr": "^2.0.3",
+                "destr": "^2.0.5",
                 "error-stack-parser-es": "^1.0.5",
                 "execa": "^8.0.1",
-                "fast-npm-meta": "^0.3.1",
-                "get-port-please": "^3.1.2",
+                "fast-npm-meta": "^0.4.6",
+                "get-port-please": "^3.2.0",
                 "hookable": "^5.5.3",
                 "image-meta": "^0.2.1",
                 "is-installed-globally": "^1.0.0",
-                "launch-editor": "^2.10.0",
-                "local-pkg": "^1.1.1",
+                "launch-editor": "^2.11.1",
+                "local-pkg": "^1.1.2",
                 "magicast": "^0.3.5",
-                "nypm": "^0.6.0",
+                "nypm": "^0.6.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
                 "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.1.0",
-                "semver": "^7.7.1",
-                "simple-git": "^3.27.0",
+                "pkg-types": "^2.3.0",
+                "semver": "^7.7.2",
+                "simple-git": "^3.28.0",
                 "sirv": "^3.0.1",
                 "structured-clone-es": "^1.0.0",
-                "tinyglobby": "^0.2.12",
-                "vite-plugin-inspect": "^11.0.0",
-                "vite-plugin-vue-tracer": "^0.1.1",
+                "tinyglobby": "^0.2.14",
+                "vite-plugin-inspect": "^11.3.2",
+                "vite-plugin-vue-tracer": "^1.0.0",
                 "which": "^5.0.0",
-                "ws": "^8.18.1"
+                "ws": "^8.18.3"
             },
             "bin": {
                 "devtools": "cli.mjs"
@@ -2046,36 +1978,103 @@
             }
         },
         "node_modules/@nuxt/devtools-kit": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.3.1.tgz",
-            "integrity": "sha512-sggap7UTV0823cZk1buCEdd3KG+dMo73DpBuN+zHFC8UG3PfSKDlbVmQGb0TegxWTXG6BwItNQo8gd+pZzf/MA==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.6.3.tgz",
+            "integrity": "sha512-cDmai3Ws6AbJlYy1p4CCwc718cfbqtAjXe6oEc6q03zoJnvX1PsvKUfmU+yuowfqTSR6DZRmH4SjCBWuMjgaKQ==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^3.16.1",
-                "@nuxt/schema": "^3.16.1",
+                "@nuxt/kit": "^3.18.1",
                 "execa": "^8.0.1"
             },
             "peerDependencies": {
                 "vite": ">=6.0"
             }
         },
+        "node_modules/@nuxt/devtools-kit/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
         "node_modules/@nuxt/devtools-wizard": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-2.3.1.tgz",
-            "integrity": "sha512-FqJVncQ9XiVR3uVwnqxHysCShfwrsK8JL4Q8rNrQoY9ly0Q7h6vimX44asFZSSCQ25WYo74PikdvVKV/bZW+qg==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-2.6.3.tgz",
+            "integrity": "sha512-FWXPkuJ1RUp+9nWP5Vvk29cJPNtm4OO38bgr9G8vGbqcRznzgaSODH/92c8sm2dKR7AF+9MAYLL+BexOWOkljQ==",
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.4.2",
-                "diff": "^7.0.0",
+                "diff": "^8.0.2",
                 "execa": "^8.0.1",
                 "magicast": "^0.3.5",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.1.0",
+                "pkg-types": "^2.3.0",
                 "prompts": "^2.4.2",
-                "semver": "^7.7.1"
+                "semver": "^7.7.2"
             },
             "bin": {
                 "devtools-wizard": "cli.mjs"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
             }
         },
         "node_modules/@nuxt/devtools/node_modules/isexe": {
@@ -2086,6 +2085,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/@nuxt/devtools/node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "license": "MIT"
         },
         "node_modules/@nuxt/devtools/node_modules/which": {
             "version": "5.0.0",
@@ -2187,146 +2192,6 @@
                 "eslint": "^9.0.0"
             }
         },
-        "node_modules/@nuxt/eslint/node_modules/@nuxt/devtools-kit": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.6.2.tgz",
-            "integrity": "sha512-esErdMQ0u3wXXogKQ3IE2m0fxv52w6CzPsfsXF4o5ZVrUQrQaH58ygupDAQTYdlGTgtqmEA6KkHTGG5cM6yxeg==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^3.17.6",
-                "execa": "^8.0.1"
-            },
-            "peerDependencies": {
-                "vite": ">=6.0"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/@nuxt/devtools-kit/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/@nuxt/kit": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.0.3.tgz",
-            "integrity": "sha512-9+lwvP4n8KhO91azoebO0o39smESGzEV4HU6nef9HIFyt04YwlVMY37Pk63GgZn0WhWVjyPWcQWs0rUdZUYcPw==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/@nuxt/eslint/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/@nuxt/image": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/@nuxt/image/-/image-1.11.0.tgz",
@@ -2352,9 +2217,9 @@
             }
         },
         "node_modules/@nuxt/image/node_modules/@nuxt/kit": {
-            "version": "3.19.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.1.tgz",
-            "integrity": "sha512-cLKNdmfFk49o9Tt7g+vwD9rYN7cLg0D6K6CRB+4aaQYxveJXQbZGgZ4z7CGq5HxIG22Ki8G3XSXaiN1s6lVyZg==",
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.2.0",
@@ -2375,7 +2240,7 @@
                 "scule": "^1.3.0",
                 "semver": "^7.7.2",
                 "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
+                "tinyglobby": "^0.2.15",
                 "ufo": "^1.6.1",
                 "unctx": "^2.4.1",
                 "unimport": "^5.2.0",
@@ -2385,95 +2250,33 @@
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/@nuxt/image/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@nuxt/image/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@nuxt/image/node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/@nuxt/image/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/@nuxt/kit": {
-            "version": "3.16.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.16.1.tgz",
-            "integrity": "sha512-Perby8hJGUeCWad5oTVXb/Ibvp18ZCUC5PxHHu+acMDmVfnxSo48yqk7qNd09VkTF3LEzoEjNZpmW2ZWN0ry7A==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.2.tgz",
+            "integrity": "sha512-P5q41xeEOa6ZQC0PvIP7TSBmOAMxXK4qihDcCbYIJq8RcVsEPbGZVlidmxE6EOw1ucSyodq9nbV31FAKwoL4NQ==",
             "license": "MIT",
             "dependencies": {
-                "c12": "^3.0.2",
+                "c12": "^3.2.0",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
-                "destr": "^2.0.3",
+                "destr": "^2.0.5",
                 "errx": "^0.1.0",
-                "exsolve": "^1.0.4",
-                "globby": "^14.1.0",
-                "ignore": "^7.0.3",
-                "jiti": "^2.4.2",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
                 "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
+                "mlly": "^1.8.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.1.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
                 "scule": "^1.3.0",
-                "semver": "^7.7.1",
-                "std-env": "^3.8.1",
-                "ufo": "^1.5.4",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
                 "unctx": "^2.4.1",
-                "unimport": "^4.1.2",
+                "unimport": "^5.2.0",
                 "untyped": "^2.0.0"
             },
             "engines": {
@@ -2481,15 +2284,18 @@
             }
         },
         "node_modules/@nuxt/schema": {
-            "version": "3.16.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.16.1.tgz",
-            "integrity": "sha512-Ri8bmT6MljpVR4DlXf9+acfgGaI4OTEdAzJU5aF2rJS78abtpnBxjXBG65kuhoL1LUlfKppDl8fTkUw5LM2JXQ==",
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.19.2.tgz",
+            "integrity": "sha512-kMN2oIfrsMc8ACrRweYRG7Q44/KuHG5y7L+4szQhfOgN78OiYkxiM/nSsLH0K2bJq8Eavg+WGfgACj4Lsy+YqQ==",
             "license": "MIT",
             "dependencies": {
+                "@vue/shared": "^3.5.21",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
                 "pathe": "^2.0.3",
-                "std-env": "^3.8.1"
+                "pkg-types": "^2.3.0",
+                "std-env": "^3.9.0",
+                "ufo": "1.6.1"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -2521,118 +2327,131 @@
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/@nuxt/vite-builder": {
-            "version": "3.16.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.16.1.tgz",
-            "integrity": "sha512-6A/cK743xeGcoMh//Ev1HAybb5VDwovxRsNeubfuqlDxBR7WL695SAfIhEAmxpVDz8LYQBuz/NwGhTaBh7hgaQ==",
+        "node_modules/@nuxt/telemetry/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "3.16.1",
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/telemetry/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@nuxt/vite-builder": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.19.2.tgz",
+            "integrity": "sha512-SESdHAKWy63RKG3uqrBEJvTbfkmEsiggmDEqjEwhBP2fe0E6bGTmLpX/Eh4AuOLbZuZOmir984OHFiM/Q/MLhg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nuxt/kit": "3.19.2",
                 "@rollup/plugin-replace": "^6.0.2",
-                "@vitejs/plugin-vue": "^5.2.3",
-                "@vitejs/plugin-vue-jsx": "^4.1.2",
+                "@vitejs/plugin-vue": "^6.0.1",
+                "@vitejs/plugin-vue-jsx": "^5.1.1",
                 "autoprefixer": "^10.4.21",
                 "consola": "^3.4.2",
-                "cssnano": "^7.0.6",
+                "cssnano": "^7.1.1",
                 "defu": "^6.1.4",
-                "esbuild": "^0.25.1",
+                "esbuild": "^0.25.9",
                 "escape-string-regexp": "^5.0.0",
-                "exsolve": "^1.0.4",
+                "exsolve": "^1.0.7",
                 "externality": "^1.0.2",
-                "get-port-please": "^3.1.2",
-                "h3": "^1.15.1",
-                "jiti": "^2.4.2",
+                "get-port-please": "^3.2.0",
+                "h3": "^1.15.4",
+                "jiti": "^2.5.1",
                 "knitwork": "^1.2.0",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
+                "magic-string": "^0.30.19",
+                "mlly": "^1.8.0",
                 "mocked-exports": "^0.1.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.1.0",
-                "postcss": "^8.5.3",
-                "rollup-plugin-visualizer": "^5.14.0",
-                "std-env": "^3.8.1",
-                "ufo": "^1.5.4",
-                "unenv": "^2.0.0-rc.15",
-                "unplugin": "^2.2.1",
-                "vite": "^6.2.2",
-                "vite-node": "^3.0.9",
-                "vite-plugin-checker": "^0.9.1",
-                "vue-bundle-renderer": "^2.1.1"
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
+                "postcss": "^8.5.6",
+                "rollup-plugin-visualizer": "^6.0.3",
+                "std-env": "^3.9.0",
+                "ufo": "^1.6.1",
+                "unenv": "^2.0.0-rc.21",
+                "vite": "^7.1.5",
+                "vite-node": "^3.2.4",
+                "vite-plugin-checker": "^0.10.3",
+                "vue-bundle-renderer": "^2.1.2"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
                 "vue": "^3.3.4"
             }
         },
-        "node_modules/@nuxt/vite-builder/node_modules/@volar/language-core": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
-            "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+        "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
-                "@volar/source-map": "2.4.15"
-            }
-        },
-        "node_modules/@nuxt/vite-builder/node_modules/@volar/source-map": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
-            "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@nuxt/vite-builder/node_modules/@volar/typescript": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
-            "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/language-core": "2.4.15",
-                "path-browserify": "^1.0.1",
-                "vscode-uri": "^3.0.8"
-            }
-        },
-        "node_modules/@nuxt/vite-builder/node_modules/@vue/language-core": {
-            "version": "2.2.12",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
-            "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/language-core": "2.4.15",
-                "@vue/compiler-dom": "^3.5.0",
-                "@vue/compiler-vue2": "^2.7.16",
-                "@vue/shared": "^3.5.0",
-                "alien-signals": "^1.0.3",
-                "minimatch": "^9.0.3",
-                "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1"
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
             },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "engines": {
+                "node": ">=18.12.0"
             }
-        },
-        "node_modules/@nuxt/vite-builder/node_modules/alien-signals": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
-            "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@nuxt/vite-builder/node_modules/escape-string-regexp": {
             "version": "5.0.0",
@@ -2701,19 +2520,19 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/vite-plugin-checker": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.9.1.tgz",
-            "integrity": "sha512-neH3CSNWdkZ+zi+WPt/0y5+IO2I0UAI0NX6MaXqU/KxN1Lz6np/7IooRB6VVAMBa4nigqm1GRF6qNa4+EL5jDQ==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.10.3.tgz",
+            "integrity": "sha512-f4sekUcDPF+T+GdbbE8idb1i2YplBAoH+SfRS0e/WRBWb2rYb1Jf5Pimll0Rj+3JgIYWwG2K5LtBPCXxoibkLg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
+                "@babel/code-frame": "^7.27.1",
                 "chokidar": "^4.0.3",
                 "npm-run-path": "^6.0.0",
                 "picocolors": "^1.1.1",
-                "picomatch": "^4.0.2",
+                "picomatch": "^4.0.3",
                 "strip-ansi": "^7.1.0",
                 "tiny-invariant": "^1.3.3",
-                "tinyglobby": "^0.2.12",
+                "tinyglobby": "^0.2.14",
                 "vscode-uri": "^3.1.0"
             },
             "engines": {
@@ -2729,7 +2548,7 @@
                 "vite": ">=2.0.0",
                 "vls": "*",
                 "vti": "*",
-                "vue-tsc": "~2.2.2"
+                "vue-tsc": "~2.2.10 || ^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@biomejs/biome": {
@@ -2761,24 +2580,6 @@
                 }
             }
         },
-        "node_modules/@nuxt/vite-builder/node_modules/vue-tsc": {
-            "version": "2.2.12",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
-            "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/typescript": "2.4.15",
-                "@vue/language-core": "2.2.12"
-            },
-            "bin": {
-                "vue-tsc": "bin/vue-tsc.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=5.0.0"
-            }
-        },
         "node_modules/@nuxtjs/color-mode": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-3.5.2.tgz",
@@ -2790,6 +2591,60 @@
                 "pathe": "^1.1.2",
                 "pkg-types": "^1.2.1",
                 "semver": "^7.6.3"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pkg-types": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+            "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.2",
+                "exsolve": "^1.0.7",
+                "pathe": "^2.0.3"
             }
         },
         "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
@@ -2811,6 +2666,13 @@
                 "pathe": "^2.0.1"
             }
         },
+        "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/pathe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2819,19 +2681,19 @@
             "license": "MIT"
         },
         "node_modules/@nuxtjs/robots": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-5.4.0.tgz",
-            "integrity": "sha512-E+bzaVsRQRgyN1RjhUexaqVZDV3MLKHff2e3WYHPiXrUNnOQ/RverO3D0yrP7fH5HqOBG0nBV6X3gD/q3+kUEA==",
+            "version": "5.5.5",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-5.5.5.tgz",
+            "integrity": "sha512-ZJZQHFrahJITNakvRx2+TAHH2xQMO0BHYANlPVQ2ZU7s3wQMnOjaYAyAuTjzbHlLqUqurpQQtYT3WNrsl3QpJg==",
             "license": "MIT",
             "dependencies": {
                 "@fingerprintjs/botd": "^1.9.1",
-                "@nuxt/kit": "^3.17.6",
+                "@nuxt/kit": "^4.1.2",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
-                "nuxt-site-config": "^3.2.2",
+                "nuxt-site-config": "^3.2.5",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "sirv": "^3.0.1",
+                "pkg-types": "^2.3.0",
+                "sirv": "^3.0.2",
                 "std-env": "^3.9.0",
                 "ufo": "^1.6.1"
             },
@@ -2839,234 +2701,44 @@
                 "url": "https://github.com/sponsors/harlan-zw"
             }
         },
-        "node_modules/@nuxtjs/robots/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxtjs/robots/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@nuxtjs/robots/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@nuxtjs/robots/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/@nuxtjs/robots/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/@nuxtjs/seo": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/seo/-/seo-3.1.0.tgz",
-            "integrity": "sha512-BWCAdC0ePRijCCVcero5TfYfCpEgpRwaOIWB6iVSjycohgSISEo6mg/J+g/3SiXIDhbz9czmPdoQgWTR7BDHPw==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/seo/-/seo-3.2.2.tgz",
+            "integrity": "sha512-tES+NakNvnmh3eEUkBBuMpHEo3O9mj5iKY3st9LSso1/nCJDuDAg6XvvrM3ZytMnGDmhaEixSCVdZkhhKEGiZQ==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^3.17.5",
-                "@nuxtjs/robots": "^5.2.11",
-                "@nuxtjs/sitemap": "^7.4.2",
-                "nuxt-link-checker": "^4.3.1",
-                "nuxt-og-image": "^5.1.8",
-                "nuxt-schema-org": "^5.0.6",
-                "nuxt-seo-utils": "^7.0.12",
-                "nuxt-site-config": "^3.2.2"
+                "@nuxt/kit": "^4.1.2",
+                "@nuxtjs/robots": "^5.5.5",
+                "@nuxtjs/sitemap": "^7.4.7",
+                "nuxt-link-checker": "^4.3.2",
+                "nuxt-og-image": "^5.1.11",
+                "nuxt-schema-org": "^5.0.9",
+                "nuxt-seo-utils": "^7.0.17",
+                "nuxt-site-config": "^3.2.7"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
             }
         },
-        "node_modules/@nuxtjs/seo/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxtjs/seo/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@nuxtjs/seo/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@nuxtjs/seo/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/@nuxtjs/seo/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/@nuxtjs/sitemap": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-7.4.3.tgz",
-            "integrity": "sha512-edJ0bVuKS87PefTnKVMqcEwSZbur0yLg2eCKU2kjNDI1jC9tOnCHwXMHQficiKPXZolzqmlK7+U23Tv95OzVbg==",
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-7.4.7.tgz",
+            "integrity": "sha512-DUhX92lnCJD6tpghUmfmRIsSIoiXMS2SQ2Yd9Tg1+SnZskiKX+DGwLeAeHX8r0/9Pl/bTDpmYhs1snWcCoIkXA==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "^2.5.0",
-                "@nuxt/kit": "^3.17.5",
-                "chalk": "^5.4.1",
+                "@nuxt/devtools-kit": "^2.6.3",
+                "@nuxt/kit": "^4.1.2",
+                "chalk": "^5.6.2",
                 "defu": "^6.1.4",
                 "fast-xml-parser": "^5.2.5",
                 "h3-compression": "^0.3.2",
-                "nuxt-site-config": "^3.2.2",
+                "nuxt-site-config": "^3.2.5",
                 "ofetch": "^1.4.1",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.1.1",
+                "pkg-types": "^2.3.0",
                 "radix3": "^1.1.2",
                 "semver": "^7.7.2",
-                "sirv": "^3.0.1",
+                "sirv": "^3.0.2",
                 "std-env": "^3.9.0",
                 "ufo": "^1.6.1",
                 "ultrahtml": "^1.6.0"
@@ -3076,114 +2748,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/@nuxt/devtools-kit": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.6.2.tgz",
-            "integrity": "sha512-esErdMQ0u3wXXogKQ3IE2m0fxv52w6CzPsfsXF4o5ZVrUQrQaH58ygupDAQTYdlGTgtqmEA6KkHTGG5cM6yxeg==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^3.17.6",
-                "execa": "^8.0.1"
-            },
-            "peerDependencies": {
-                "vite": ">=6.0"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/@nuxtjs/sitemap/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
             }
         },
         "node_modules/@nuxtjs/tailwindcss": {
@@ -3211,10 +2775,61 @@
                 "unctx": "^2.4.1"
             }
         },
-        "node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.56.5.tgz",
-            "integrity": "sha512-rj4WZqQVJQgLnGnDu2ciIOC5SqcBPc4x11RN0NwuedSGzny5mtBdNVLwt0+8iB15lIjrOKg5pjYJ8GQVPca5HA==",
+        "node_modules/@nuxtjs/tailwindcss/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-android-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
+            "integrity": "sha512-ZbJmAfXvNAamOSnXId3BiM3DiuzlD1isqKjtmRFb/hpvChHHA23FSPrFcO16w+ugZKg33sZ93FinFkKtlC4hww==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-darwin-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
+            "integrity": "sha512-ewmNsTY8YbjWOI8+EOWKTVATOYvG4Qq4zQHH5VFBeqhQPVusY1ORD6Ei+BijVKrnlbpjibLlkTl8IWqXCGK89A==",
             "cpu": [
                 "arm64"
             ],
@@ -3227,10 +2842,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.56.5.tgz",
-            "integrity": "sha512-Rr7aMkqcxGIM6fgkpaj9SJj0u1O1g+AT7mJwmdi5PLSQRPR4CkDKfztEnAj5k+d2blWvh9nPZH8G0OCwxIHk1Q==",
+        "node_modules/@oxc-minify/binding-darwin-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
+            "integrity": "sha512-qDH4w4EYttSC3Cs2VCh+CiMYKrcL2SNmnguBZXoUXe/RNk3csM+RhgcwdpX687xGvOhTFhH5PCIA84qh3ZpIbQ==",
             "cpu": [
                 "x64"
             ],
@@ -3243,10 +2858,26 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.56.5.tgz",
-            "integrity": "sha512-jcFCThrWUt5k1GM43tdmI1m2dEnWUPPHHTWKBJbZBXzXLrJJzkqv5OU87Spf1004rYj9swwpa13kIldFwMzglA==",
+        "node_modules/@oxc-minify/binding-freebsd-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
+            "integrity": "sha512-5kxjHlSev2A09rDeITk+LMHxSrU3Iu8pUb0Zp4m+ul8FKlB9FrvFkAYwbctin6g47O98s3Win7Ewhy0w8JaiUA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
+            "integrity": "sha512-NjbGXnNaAl5EgyonaDg2cPyH2pTf5a/+AP/5SRCJ0KetpXV22ZSUCvcy04Yt4QqjMcDs+WnJaGVxwx15Ofr6Gw==",
             "cpu": [
                 "arm"
             ],
@@ -3259,10 +2890,26 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.56.5.tgz",
-            "integrity": "sha512-zo/9RDgWvugKxCpHHcAC5EW0AqoEvODJ4Iv4aT1Xonv6kcydbyPSXJBQhhZUvTXTAFIlQKl6INHl+Xki9Qs3fw==",
+        "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
+            "integrity": "sha512-llAjfCA0iV2LMMl+LTR3JhqAc2iQmj+DTKd0VWOrbNOuNczeE9D5kJFkqYplD73LrkuqxrX9oDeUjjeLdVBPXw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
+            "integrity": "sha512-tf2Shom09AaSmu7U1hYYcEFF/cd+20HtmQ8eyGsRkqD5bqUj6lDu8TNSU9FWZ9tcZ83NzyFMwXZWHyeeIIbpxw==",
             "cpu": [
                 "arm64"
             ],
@@ -3275,10 +2922,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.56.5.tgz",
-            "integrity": "sha512-SCIqrL5apVbrtMoqOpKX/Ez+c46WmW0Tyhtu+Xby281biH+wYu70m+fux9ZsGmbHc2ojd4FxUcaUdCZtb5uTOQ==",
+        "node_modules/@oxc-minify/binding-linux-arm64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
+            "integrity": "sha512-pgWeYfSprtpnJVea9Q5eI6Eo80lDGlMw2JdcSMXmShtBjEhBl6bvDNHlV+6kNfh7iT65y/uC6FR8utFrRghu8A==",
             "cpu": [
                 "arm64"
             ],
@@ -3291,10 +2938,42 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.56.5.tgz",
-            "integrity": "sha512-I2mpX35NWo83hay4wrnzFLk3VuGK1BBwHaqvEdqsCode8iG8slYJRJPICVbCEWlkR3rotlTQ+608JcRU0VqZ5Q==",
+        "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
+            "integrity": "sha512-O1QPczlT+lqNZVeKOdFxxL+s1RIlnixaJYFLrcqDcRyn82MGKLz7sAenBTFRQoIfLnSxtMGL6dqHOefYkQx7Cg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
+            "integrity": "sha512-tcwt3ZUWOKfNLXN2edxFVHMlIuPvbuyMaKmRopgljSCfFcNHWhfTNlxlvmECRNhuQ91EcGwte6F1dwoeMCNd7A==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-x64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
+            "integrity": "sha512-Xf4AXF14KXUzSnfgTcFLFSM0TykJhFw14+xwNvlAb6WdqXAKlMrz9joIAezc8dkW1NNscCVTsqBUPJ4RhvCM1Q==",
             "cpu": [
                 "x64"
             ],
@@ -3307,10 +2986,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.56.5.tgz",
-            "integrity": "sha512-xfzUHGYOh3PGWZdBuY5r1czvE8EGWPAmhTWHqkw3/uAfUVWN/qrrLjMojiaiWyUgl/9XIFg05m5CJH9dnngh5Q==",
+        "node_modules/@oxc-minify/binding-linux-x64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
+            "integrity": "sha512-LIqvpx9UihEW4n9QbEljDnfUdAWqhr6dRqmzSFwVAeLZRUECluLCDdsdwemrC/aZkvnisA4w0LFcFr3HmeTLJg==",
             "cpu": [
                 "x64"
             ],
@@ -3323,26 +3002,26 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.56.5.tgz",
-            "integrity": "sha512-+z3Ofmc1v5kcu8fXgG5vn7T1f52P47ceTTmTXsm5HPY7rq5EMYRUaBnxH6cesXwY1OVVCwYlIZbCiy8Pm1w8zQ==",
+        "node_modules/@oxc-minify/binding-wasm32-wasi": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
+            "integrity": "sha512-h0xluvc+YryfH5G5dndjGHuA/D4Kp85EkPMxqoOjNudOKDCtdobEaC9horhCqnOOQ0lgn+PGFl3w8u4ToOuRrA==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.7"
+                "@napi-rs/wasm-runtime": "^1.0.3"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.56.5.tgz",
-            "integrity": "sha512-pRg8QrbMh8PgnXBreiONoJBR306u+JN19BXQC7oKIaG4Zxt9Mn8XIyuhUv3ytqjLudSiG2ERWQUoCGLs+yfW0A==",
+        "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
+            "integrity": "sha512-fgxSx+TUc7e2rNtRAMnhHrjqh1e8p/JKmWxRZXtkILveMr/TOHGiDis7U3JJbwycmTZ+HSsJ/PNFQl+tKzmDxw==",
             "cpu": [
                 "arm64"
             ],
@@ -3355,10 +3034,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.56.5.tgz",
-            "integrity": "sha512-VALZNcuyw/6rwsxOACQ2YS6rey2d/ym4cNfXqJrHB/MZduAPj4xvij72gHGu3Ywm31KVGLVWk/mrMRiM9CINcA==",
+        "node_modules/@oxc-minify/binding-win32-x64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
+            "integrity": "sha512-K6TTrlitEJgD0FGIW2r0t3CIJNqBkzHT97h49gZLS24ey2UG1zKt27iSHkpXMJYDiG97ZD2yv3pSph1ctMlFXw==",
             "cpu": [
                 "x64"
             ],
@@ -3371,25 +3050,493 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@oxc-parser/wasm": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/wasm/-/wasm-0.60.0.tgz",
-            "integrity": "sha512-Dkf9/D87WGBCW3L0+1DtpAfL4SrNsgeRvxwjpKCtbH7Kf6K+pxrT0IridaJfmWKu1Ml+fDvj+7HEyBcfUC/TXQ==",
+        "node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
+            "integrity": "sha512-3APxTyYaAjpW5zifjzfsPgoIa4YHwA5GBjtgLRQpGVXCykXBIEbUTokoAs411ZuOwS3sdTVXBTGAdziXRd8rUg==",
+            "cpu": [
+                "arm64"
+            ],
             "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
+            "integrity": "sha512-99e8E76M+k3Gtwvs5EU3VTs2hQkJmvnrl/eu7HkBUc9jLFHA4nVjYSgukMuqahWe270udUYEPRfcWKmoE1Nukg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
+            "integrity": "sha512-2rRo6Dz560/4ot5Q0KPUTEunEObkP8mDC9mMiH0RJk1FiOb9c+xpPbkYoUHNKuVMm8uIoiBCxIAbPtBhs9QaXQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
+            "integrity": "sha512-uR+WZAvWkFQPVoeqXgQFr7iy+3hEI295qTbQ4ujmklgM5eTX3YgMFoIV00Stloxfd1irSDDSaK7ySnnzF6mRJg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
+            "integrity": "sha512-Emm1NpVGKbwzQOIZJI8ZuZu0z8FAd5xscqdS6qpDFpDdEMxk6ab7o3nM8V09RhNCORAzeUlk4TBHQ2Crzjd50A==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
+            "integrity": "sha512-1PPCxRZSJXzQaqc8y+wH7EqPgSfQ/JU3pK6WTN/1SUe/8paNVSKKqk175a8BbRVxGUtPnwEG89pi+xfPTSE7GA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
+            "integrity": "sha512-fcnnsfcyLamJOMVKq+BQ8dasb8gRnZtNpCUfZhaEFAdXQ7J2RmZreFzlygcn80iti0V7c5LejcjHbF4IdK3GAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
+            "integrity": "sha512-tBPkSPgRSSbmrje8CUovISi/Hj/tWjZJ3n/qnrjx2B+u86hWtwLsngtPDQa5d4seSyDaHSx6tNEUcH7+g5Ee0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
+            "integrity": "sha512-z4UKGM4wv2wEAQAlx2pBq6+pDJw5J/5oDEXqW6yBSLbWLjLDo4oagmRSE3+giOWteUa+0FVJ+ypq4iYxBkYSWg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
+            "integrity": "sha512-6W1ENe/nZtr2TBnrEzmdGEraEAdZOiH3YoUNNeQWuqwLkmpoHTJJdclieToPe/l2IKJ4WL3FsSLSGHE8yt/OEg==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
+            "integrity": "sha512-s3kB/Ii3X3IOZ27Iu7wx2zYkIcDO22Emu32SNC6kkUSy09dPBc1yaW14TnAkPMe/rvtuzR512JPWj3iGpl+Dng==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
+            "integrity": "sha512-3+M9hfrZSDi4+Uy4Ll3rtOuVG3IHDQlj027jgtmAAHJK1eqp4CQfC7rrwE+LFUqUwX+KD2GwlxR+eHyyEf5Gbg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
+            "integrity": "sha512-2jgeEeOa4GbQQg2Et/gFTgs5wKS/+CxIg+CN2mMOJ4EqbmvUVeGiumO01oFOWTYnJy1oONwIocBzrnMuvOcItA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
             "dependencies": {
-                "@oxc-project/types": "^0.60.0"
+                "@napi-rs/wasm-runtime": "^1.0.3"
             },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
+            "integrity": "sha512-KZp9poaBaVvuFM0TrsHCDOjPQK5eMDXblz21boMhKHGW5/bOlkMlg3CYn5j0f67FkK68NSdNKREMxmibBeXllQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
+            "integrity": "sha512-86uisngtp/8XdcerIKxMyJTqgDSTJatkfpylpUH0d96W8Bb9E+bVvM2fIIhLWB0Eb03PeY2BdIT7DNIln9TnHg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.87.0.tgz",
+            "integrity": "sha512-ipZFWVGE9fADBVXXWJWY/cxpysc41Gt5upKDeb32F6WMgFyO7XETUMVq8UuREKCih+Km5E6p2VhEvf6Fuhey6g==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
-        "node_modules/@oxc-project/types": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.60.0.tgz",
-            "integrity": "sha512-prhfNnb3ATFHOCv7mzKFfwLij5RzoUz6Y1n525ZhCEqfq5wreCXL+DyVoq3ShukPo7q45ZjYIdjFUgjj+WKzng==",
+        "node_modules/@oxc-transform/binding-android-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
+            "integrity": "sha512-B7W6J8T9cS054LUGLfYkYz8bz5+t+4yPftZ67Bn6MJ03okMLnbbEfm1bID1tqcP5tJwMurTILVy/dQfDYDcMgQ==",
+            "cpu": [
+                "arm64"
+            ],
             "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-darwin-arm64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
+            "integrity": "sha512-HImW3xOPx7FHKqfC5WfE82onhRfnWQUiB7R+JgYrk+7NR404h3zANSPzu3V/W9lbDxlmHTcqoD2LKbNC5j0TQA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-darwin-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
+            "integrity": "sha512-MDbgugi6mvuPTfS78E2jyozm7493Kuqmpc5r406CsUdEsXlnsF+xvmKlrW9ZIkisO74dD+HWouSiDtNyPQHjlw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-freebsd-x64": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
+            "integrity": "sha512-N0M5D/4haJw7BMn2WZ3CWz0WkdLyoK1+3KxOyCv2CPedMCxx6eQay2AtJxSzj9tjVU1+ukbSb2fDO24JIJGsVA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
+            "integrity": "sha512-PubObCNOUOzm1S+P0yn7S+/6xRLbSPMqhgrb73L3p+J1Z20fv/FYVg0kFd36Yho24TSC/byOkebEZWAtxCasWw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
+            "integrity": "sha512-Nk2d/FS7sMCmCl99vHojzigakjDPamkjOXs2i+H71o/NqytS0pk3M+tXat8M3IGpeLJIEszA5Mv+dcq731nlYA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
+            "integrity": "sha512-BxFkIcso2V1+FCDoU+KctxvJzSQVSnEZ5EEQ8O3Up9EoFVQRnZ8ktXvqYj2Oqvc4IYPskLPsKUgc9gdK8wGhUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
+            "integrity": "sha512-MZ1/TNaebhXK73j1UDfwyBFnAy0tT3n6otOkhlt1vlJwqboUS/D7E/XrCZmAuHIfVPxAXRPovkl7kfxLB43SKw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
+            "integrity": "sha512-JCWE6n4Hicu0FVbvmLdH/dS8V6JykOUsbrbDYm6JwFlHr4eFTTlS2B+mh5KPOxcdeOlv/D/XRnvMJ6WGYs25EA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
+            "integrity": "sha512-n2NTgM+3PqFagJV9UXRDNOmYesF+TO9SF9FeHqwVmW893ayef9KK+vfWAAhvOYHXYaKWT5XoHd87ODD7nruyhw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-x64-gnu": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
+            "integrity": "sha512-ZOKW3wx0bW2O7jGdOzr8DyLZqX2C36sXvJdsHj3IueZZ//d/NjLZqEiUKz+q0JlERHtCVKShQ5PLaCx7NpuqNg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-x64-musl": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
+            "integrity": "sha512-eIspx/JqkVMPK1CAYEOo2J8o49s4ZTf+32MSMUknIN2ZS1fvRmWS0D/xFFaLP/9UGhdrXRIPbn/iSYEA8JnV/g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-wasm32-wasi": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
+            "integrity": "sha512-4uRjJQnt/+kmJUIC6Iwzn+MqqZhLP1zInPtDwgL37KI4VuUewUQWoL+sggMssMEgm7ZJwOPoZ6piuSWwMgOqgQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
+            "integrity": "sha512-l/qSi4/N5W1yXKU9+1gWGo0tBoRpp4zvHYrpsbq3zbefPL4VYdA0gKF7O10/ZQVkYylzxiVh2zpYO34/FbZdIg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-win32-x64-msvc": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
+            "integrity": "sha512-jG/MhMjfSdyj5KyhnwNWr4mnAlAsz+gNUYpjQ+UXWsfsoB3f8HqbsTkG02RBtNa/IuVQYvYYVf1eIimNN3gBEQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@parcel/watcher": {
@@ -3728,6 +3875,40 @@
                 "pinia": "^3.0.3"
             }
         },
+        "node_modules/@pinia/nuxt/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3739,21 +3920,18 @@
             }
         },
         "node_modules/@polka/url": {
-            "version": "1.0.0-next.28",
-            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-            "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
             "license": "MIT"
         },
         "node_modules/@poppinss/colors": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.4.tgz",
-            "integrity": "sha512-FA+nTU8p6OcSH4tLDY5JilGYr1bVWHpNmcLr7xmMEdbWmKHa+3QZ+DqefrXKmdjO/brHTnQZo20lLSjaO7ydog==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.5.tgz",
+            "integrity": "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==",
             "license": "MIT",
             "dependencies": {
                 "kleur": "^4.1.5"
-            },
-            "engines": {
-                "node": ">=18.16.0"
             }
         },
         "node_modules/@poppinss/colors/node_modules/kleur": {
@@ -3766,20 +3944,20 @@
             }
         },
         "node_modules/@poppinss/dumper": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.3.tgz",
-            "integrity": "sha512-iombbn8ckOixMtuV1p3f8jN6vqhXefNjJttoPaJDMeIk/yIGhkkL3OrHkEjE9SRsgoAx1vBUU2GtgggjvA5hCA==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.4.tgz",
+            "integrity": "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ==",
             "license": "MIT",
             "dependencies": {
-                "@poppinss/colors": "^4.1.4",
-                "@sindresorhus/is": "^7.0.1",
+                "@poppinss/colors": "^4.1.5",
+                "@sindresorhus/is": "^7.0.2",
                 "supports-color": "^10.0.0"
             }
         },
         "node_modules/@poppinss/dumper/node_modules/@sindresorhus/is": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.1.tgz",
-            "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.0.tgz",
+            "integrity": "sha512-7F/yz2IphV39hiS2zB4QYVkivrptHHh0K8qJJd9HhuWSdvf8AN7NpebW3CcDZDBQsUPMoDKWsY2WWgW7bqOcfA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -3789,9 +3967,9 @@
             }
         },
         "node_modules/@poppinss/dumper/node_modules/supports-color": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
-            "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -3801,80 +3979,10 @@
             }
         },
         "node_modules/@poppinss/exception": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.1.tgz",
-            "integrity": "sha512-aQypoot0HPSJa6gDPEPTntc1GT6QINrSbgRlRhadGW2WaYqUK3tK4Bw9SBMZXhmxd3GeAlZjVcODHgiu+THY7A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@redocly/ajv": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-            "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js-replace": "^1.0.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
+            "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
             "license": "MIT"
-        },
-        "node_modules/@redocly/config": {
-            "version": "0.22.1",
-            "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.1.tgz",
-            "integrity": "sha512-1CqQfiG456v9ZgYBG9xRQHnpXjt8WoSnDwdkX6gxktuK69v2037hTAR1eh0DGIqpZ1p4k82cGH8yTNwt7/pI9g==",
-            "license": "MIT"
-        },
-        "node_modules/@redocly/openapi-core": {
-            "version": "1.34.0",
-            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.0.tgz",
-            "integrity": "sha512-Ji00EiLQRXq0pJIz5pAjGF9MfQvQVsQehc6uIis6sqat8tG/zh25Zi64w6HVGEDgJEzUeq/CuUlD0emu3Hdaqw==",
-            "license": "MIT",
-            "dependencies": {
-                "@redocly/ajv": "^8.11.2",
-                "@redocly/config": "^0.22.0",
-                "colorette": "^1.2.0",
-                "https-proxy-agent": "^7.0.5",
-                "js-levenshtein": "^1.1.6",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^5.0.1",
-                "pluralize": "^8.0.0",
-                "yaml-ast-parser": "0.0.43"
-            },
-            "engines": {
-                "node": ">=18.17.0",
-                "npm": ">=9.5.0"
-            }
-        },
-        "node_modules/@redocly/openapi-core/node_modules/colorette": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-            "license": "MIT"
-        },
-        "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/@resvg/resvg-js": {
             "version": "2.6.2",
@@ -4100,6 +4208,12 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.29",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
+            "integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
+            "license": "MIT"
+        },
         "node_modules/@rollup/plugin-alias": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
@@ -4118,9 +4232,9 @@
             }
         },
         "node_modules/@rollup/plugin-commonjs": {
-            "version": "28.0.3",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.3.tgz",
-            "integrity": "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==",
+            "version": "28.0.6",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
+            "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.1",
@@ -4253,9 +4367,9 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
-            "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -4275,9 +4389,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz",
-            "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+            "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
             "cpu": [
                 "arm"
             ],
@@ -4288,9 +4402,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz",
-            "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+            "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
             "cpu": [
                 "arm64"
             ],
@@ -4301,9 +4415,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz",
-            "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+            "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4314,9 +4428,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz",
-            "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+            "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
             "cpu": [
                 "x64"
             ],
@@ -4327,9 +4441,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz",
-            "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+            "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
             "cpu": [
                 "arm64"
             ],
@@ -4340,9 +4454,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz",
-            "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+            "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
             "cpu": [
                 "x64"
             ],
@@ -4353,9 +4467,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz",
-            "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+            "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
             "cpu": [
                 "arm"
             ],
@@ -4366,9 +4480,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz",
-            "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+            "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
             "cpu": [
                 "arm"
             ],
@@ -4379,9 +4493,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz",
-            "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+            "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
             "cpu": [
                 "arm64"
             ],
@@ -4392,9 +4506,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz",
-            "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+            "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4404,10 +4518,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz",
-            "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+            "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
             "cpu": [
                 "loong64"
             ],
@@ -4417,10 +4531,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz",
-            "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+            "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
             "cpu": [
                 "ppc64"
             ],
@@ -4431,9 +4545,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz",
-            "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+            "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -4444,9 +4558,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz",
-            "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+            "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
             "cpu": [
                 "riscv64"
             ],
@@ -4457,9 +4571,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz",
-            "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+            "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
             "cpu": [
                 "s390x"
             ],
@@ -4470,9 +4584,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
-            "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+            "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
             "cpu": [
                 "x64"
             ],
@@ -4483,9 +4597,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz",
-            "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+            "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
             "cpu": [
                 "x64"
             ],
@@ -4495,10 +4609,23 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+            "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz",
-            "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+            "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
             "cpu": [
                 "arm64"
             ],
@@ -4509,9 +4636,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz",
-            "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+            "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
             "cpu": [
                 "ia32"
             ],
@@ -4522,9 +4649,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.37.0.tgz",
-            "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+            "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
             "cpu": [
                 "x64"
             ],
@@ -4592,17 +4719,6 @@
             "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@studiometa/vue-mapbox-gl": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/@studiometa/vue-mapbox-gl/-/vue-mapbox-gl-2.7.2.tgz",
-            "integrity": "sha512-iYbS7vvUPkuKO+YI9PVqBlCPS1R7qrh4Yz9nHLJY+rU0VEVqDvu37Ies2o2gj3IF4k/VazSM6nqTQr6QCA6F3A==",
-            "license": "GPL-3.0-or-later",
-            "peerDependencies": {
-                "@mapbox/mapbox-gl-geocoder": "^5.0.1",
-                "mapbox-gl": "^2.8.2 || ^3.0.0",
-                "vue": "^3.2.37"
-            }
         },
         "node_modules/@stylistic/eslint-plugin": {
             "version": "5.3.1",
@@ -4709,14 +4825,15 @@
             "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
             "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
             "license": "ISC",
+            "optional": true,
             "engines": {
                 "node": ">=10.13.0"
             }
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4811,12 +4928,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.13.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
-            "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+            "version": "24.5.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
+            "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.20.0"
+                "undici-types": "~7.12.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -4884,16 +5001,16 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
-            "integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
+            "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.43.0",
-                "@typescript-eslint/type-utils": "8.43.0",
-                "@typescript-eslint/utils": "8.43.0",
-                "@typescript-eslint/visitor-keys": "8.43.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/type-utils": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -4907,21 +5024,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.43.0",
+                "@typescript-eslint/parser": "^8.44.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
-            "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
+            "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.43.0",
-                "@typescript-eslint/types": "8.43.0",
-                "@typescript-eslint/typescript-estree": "8.43.0",
-                "@typescript-eslint/visitor-keys": "8.43.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4937,13 +5054,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
-            "integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.43.0",
-                "@typescript-eslint/types": "^8.43.0",
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4958,13 +5075,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
-            "integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.43.0",
-                "@typescript-eslint/visitor-keys": "8.43.0"
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4975,9 +5092,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
-            "integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4991,14 +5108,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
-            "integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
+            "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.43.0",
-                "@typescript-eslint/typescript-estree": "8.43.0",
-                "@typescript-eslint/utils": "8.43.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -5015,9 +5132,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
-            "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5028,15 +5145,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
-            "integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.43.0",
-                "@typescript-eslint/tsconfig-utils": "8.43.0",
-                "@typescript-eslint/types": "8.43.0",
-                "@typescript-eslint/visitor-keys": "8.43.0",
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -5056,15 +5173,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
-            "integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.43.0",
-                "@typescript-eslint/types": "8.43.0",
-                "@typescript-eslint/typescript-estree": "8.43.0"
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5079,12 +5196,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.43.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
-            "integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.43.0",
+                "@typescript-eslint/types": "8.44.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5174,62 +5291,62 @@
             }
         },
         "node_modules/@unocss/core": {
-            "version": "66.4.2",
-            "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.4.2.tgz",
-            "integrity": "sha512-cYgMQrLhB9nRekv5c+yPDDa+5dzlMkA2UMQRil0s5D9Lb5n7NsCMcr6+nfxkcSYVLy92SbwDV45c6T7vIxFTOA==",
+            "version": "66.5.1",
+            "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.5.1.tgz",
+            "integrity": "sha512-BUgN87sUIffco1d+1IuV4a1gKTI1YAFa7CTjxglLUAnopXPPJ+Q77G10zoBoFLzutiIOYLsesa3hzbQvDhosnA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@unocss/extractor-arbitrary-variants": {
-            "version": "66.4.2",
-            "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.4.2.tgz",
-            "integrity": "sha512-T/eSeodfAp7HaWnQGqVLOsW4PbKUAvuybNRyvFWThMneM2qo+dOo3kFnA5my9ULAmRSFsAlyB1DnupD3qv5Klg==",
+            "version": "66.5.1",
+            "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.5.1.tgz",
+            "integrity": "sha512-SpI2uv6bWyPyY3Tv7CxsFnHBjSTlNRcPCnfvD8gSKbAt7R+RqV0nrdkv7wSW+Woc5TYl8PClLEFSBIvo0c1h9Q==",
             "license": "MIT",
             "dependencies": {
-                "@unocss/core": "66.4.2"
+                "@unocss/core": "66.5.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@unocss/preset-mini": {
-            "version": "66.4.2",
-            "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.4.2.tgz",
-            "integrity": "sha512-Ry+5hM+XLmT8HrEb182mUfcZuyrZ8xR+TBe72DBcliJ1DhOV3K67TCxwQucfb0zHbGV71HNWdPmHsLKxPDgweQ==",
+            "version": "66.5.1",
+            "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.5.1.tgz",
+            "integrity": "sha512-kBEbA0kEXRtoHQ98o4b6f9sp1u5BanPzi+GMnWdmOWvbLAiLw1vcgXGPTX3sO+gzIMrwu0Famw6xiztWzAFjWQ==",
             "license": "MIT",
             "dependencies": {
-                "@unocss/core": "66.4.2",
-                "@unocss/extractor-arbitrary-variants": "66.4.2",
-                "@unocss/rule-utils": "66.4.2"
+                "@unocss/core": "66.5.1",
+                "@unocss/extractor-arbitrary-variants": "66.5.1",
+                "@unocss/rule-utils": "66.5.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@unocss/preset-wind3": {
-            "version": "66.4.2",
-            "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.4.2.tgz",
-            "integrity": "sha512-0Aye/PaT08M/cQhPnGKn93iEVoRJbym0/1eomMvXoL+8oc7DVry35ws06r5CLu5h1sXI6UmS6sejoePFlSkLJQ==",
+            "version": "66.5.1",
+            "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.5.1.tgz",
+            "integrity": "sha512-L1yMmKpwUWYUnScQq5jMTGvfMy/GBqVj40VS5afyOlzWnBeSkc/y4AxeW/khzGwqE/QaFcLWXiXwQVJIyxN02Q==",
             "license": "MIT",
             "dependencies": {
-                "@unocss/core": "66.4.2",
-                "@unocss/preset-mini": "66.4.2",
-                "@unocss/rule-utils": "66.4.2"
+                "@unocss/core": "66.5.1",
+                "@unocss/preset-mini": "66.5.1",
+                "@unocss/rule-utils": "66.5.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@unocss/rule-utils": {
-            "version": "66.4.2",
-            "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.4.2.tgz",
-            "integrity": "sha512-7z3IuajwXhy2cx3E0IGOFXIiuKC79/jzm4Tt56TC68nXLh/etlH0fKhxVwkZ/HbcQRpVwWyDRNcbh29pmA3DwQ==",
+            "version": "66.5.1",
+            "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.5.1.tgz",
+            "integrity": "sha512-GuBKHrDv3bdq5N1HfOr1tD864vI1EIiovBVJSfg7x9ERA4jJSnyMpGk/hbLuDIXF25EnVdZ1lFhEpJgur9+9sw==",
             "license": "MIT",
             "dependencies": {
-                "@unocss/core": "^66.4.2",
-                "magic-string": "^0.30.17"
+                "@unocss/core": "^66.5.1",
+                "magic-string": "^0.30.18"
             },
             "engines": {
                 "node": ">=14"
@@ -5449,6 +5566,18 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
@@ -5489,59 +5618,59 @@
             ]
         },
         "node_modules/@uppy/audio": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/audio/-/audio-3.0.0.tgz",
-            "integrity": "sha512-g8QD69ngLcVrcfl8F33Lv6C/Zd7YvyE6J2jpbd7fK+Q2tZVV4JFEfamVBbIC7ok3k8DxygwSYXXeB0awPg3fDA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/audio/-/audio-3.0.1.tgz",
+            "integrity": "sha512-SVqE7vbYrG6lo+Z/NGDxZPFLcoXG9nRg9pCY/oZ6HAJv3nAft0QR1CaUoNfiMVXZo178AYg/x96SEpp34Xp1BA==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/box": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/box/-/box-4.0.0.tgz",
-            "integrity": "sha512-CgDzzMRniI71m+sHHoMRIF6bIVwChWmhWStf6KvoBDBNixDP/D8Gv/MGs2+RwcMgaKmJJ5lmDhB5QJndvW9n7g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/box/-/box-4.0.1.tgz",
+            "integrity": "sha512-uFs3BRySCRb4crefJFdRBpkoRi0scefnXbu2xCJ4swH2lWJ+CT7ggoKs9Q9TdJCbekEH7U6BIgMLg8RX3eGCyQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/companion-client": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-5.0.0.tgz",
-            "integrity": "sha512-sI8AP5+mhi2HRuXFUGt2tJoIZqzHmznrPn8AdI2B/ny81upLvb5/Zo0BszlleK5iD7Wyxcn0hkBn/HQI73mcjA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-5.0.1.tgz",
+            "integrity": "sha512-Gy4NCoj5JXQqm6Gr0T6VTeKVhrf8OvnFP1Ddz35dHUsy4GkXuvcc1FMzzKpxKWONtXWz6iQZocnhslgVIZvZwQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "namespace-emitter": "^2.0.1",
                 "p-retry": "^6.1.0"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/components": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@uppy/components/-/components-1.0.1.tgz",
-            "integrity": "sha512-0e919pTTBit0A3fpjGKkGMeTI1Szwct99x1runSxEd5Y6+GNzZtc4cIStl7q/pXEjmml6/fRG0c5scmxGvVguA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@uppy/components/-/components-1.0.2.tgz",
+            "integrity": "sha512-IQNABdixuTQv1wLW4ekIqqmHqzZslreutb2Zh+lF/EZaMgO+LRlztMQvCXhgi5NRP+iL7urnssZGvh0SAn76lQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/audio": "^3.0.0",
-                "@uppy/core": "^5.0.1",
-                "@uppy/image-editor": "^4.0.0",
-                "@uppy/remote-sources": "^3.0.0",
-                "@uppy/screen-capture": "^5.0.0",
-                "@uppy/webcam": "^5.0.0",
+                "@uppy/audio": "^3.0.1",
+                "@uppy/core": "^5.0.2",
+                "@uppy/image-editor": "^4.0.1",
+                "@uppy/remote-sources": "^3.0.1",
+                "@uppy/screen-capture": "^5.0.1",
+                "@uppy/webcam": "^5.0.1",
                 "clsx": "^2.1.1",
                 "dequal": "^2.0.3",
                 "preact": "^10.5.13",
@@ -5549,14 +5678,14 @@
             }
         },
         "node_modules/@uppy/core": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@uppy/core/-/core-5.0.1.tgz",
-            "integrity": "sha512-4hLCSjwkJtSZ/W/vJp+GX+4GkSXk/ilrL5ldH0gefAg+mQVxucuLFE7Rc1QdwmUQlnhqIFOSwLAkv2jTTNXGgw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@uppy/core/-/core-5.0.2.tgz",
+            "integrity": "sha512-HY1IIr5Xff6P67MMSlG8JIgK099zFGksTnS8oBdFOGt+42ge7b6RXPH1zMerpteTLGqVfVT1kOrJLoJyTvT+NA==",
             "license": "MIT",
             "dependencies": {
                 "@transloadit/prettier-bytes": "^0.3.4",
                 "@uppy/store-default": "^5.0.0",
-                "@uppy/utils": "^7.0.1",
+                "@uppy/utils": "^7.0.2",
                 "lodash": "^4.17.21",
                 "mime-match": "^1.0.2",
                 "namespace-emitter": "^2.0.1",
@@ -5583,15 +5712,15 @@
             }
         },
         "node_modules/@uppy/dashboard": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@uppy/dashboard/-/dashboard-5.0.1.tgz",
-            "integrity": "sha512-AamgqwlLakPA4I2V51OOiwkv35B6SGXmg/++oVr1JS3IiWXDVHTznzqARxd9npvrcxE0tq4cA5bCEooXmQC8Cw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@uppy/dashboard/-/dashboard-5.0.2.tgz",
+            "integrity": "sha512-mW/bl4w1W3AUFpNHup0jJG+rAdavROyvVdLjXIr3az1Q2Hzu2IN0HgCpeVD4YEUhdLB6ToRYY4z91gyoRSZdQg==",
             "license": "MIT",
             "dependencies": {
                 "@transloadit/prettier-bytes": "^0.3.4",
-                "@uppy/provider-views": "^5.0.1",
-                "@uppy/thumbnail-generator": "^5.0.0",
-                "@uppy/utils": "^7.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/thumbnail-generator": "^5.0.1",
+                "@uppy/utils": "^7.0.2",
                 "classnames": "^2.2.6",
                 "lodash": "^4.17.21",
                 "nanoid": "^5.0.9",
@@ -5599,7 +5728,7 @@
                 "shallow-equal": "^3.0.0"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.1"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/dashboard/node_modules/nanoid": {
@@ -5621,77 +5750,77 @@
             }
         },
         "node_modules/@uppy/dropbox": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/dropbox/-/dropbox-5.0.0.tgz",
-            "integrity": "sha512-Ryi5Vi07koBqchNRCMLkBXOTUdMrQLrDkZFE0tvDUmPXIiK6FIQqAjCQaMGfRLR1CExYR3e7JgBbdjnkeihWjQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/dropbox/-/dropbox-5.0.1.tgz",
+            "integrity": "sha512-TDF+K5APDorO67tr3u/y8rQxHIM66cIXy+1Uk4PfVPlFf5YSVdwYsKn9DEqDQZWsm3YmMdFI3iVJKOGsUlvD9Q==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/facebook": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/facebook/-/facebook-5.0.0.tgz",
-            "integrity": "sha512-i87MEQcD4pxZEXlKZ9M8+zLJ/PZUN9DeavOwCuS1tTp8o/srncaeqs+hM5RO4jyDqel5AOgEEfuN3D/XRYpvww==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/facebook/-/facebook-5.0.1.tgz",
+            "integrity": "sha512-8wToHgxjoRBA4wf4PVyvzyS4PBbotdn4Gv5QjSAiLZllmQsZPHXUhdHYSlc5JANJHE6cJgNar4/1xy0goAmgpg==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/google-drive": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/google-drive/-/google-drive-5.0.0.tgz",
-            "integrity": "sha512-KwusGTS4NvkwLDQ685fcfCosNsXeAdAq2TPOJJGSoHaMcRaYvbfciOoX5i5iRTK7NWch1AL6lx09xEFdxc7y6g==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/google-drive/-/google-drive-5.0.1.tgz",
+            "integrity": "sha512-UkX322Z6V8P2/F+NH+v2APzEAtJJNH5bMBgTzk4v2oyAMFTL1wxkOm+/K8HGhwEOLiU3ta5JvXwuvVlC2uU49A==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/image-editor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/image-editor/-/image-editor-4.0.0.tgz",
-            "integrity": "sha512-5vcVLpalC+0L/7UPNRVXOHt/ZgZO0dwJfKirVwAYhOlym2aEQN8ktopgxaTLRVsYD51l25dJRwjita0aMs0SMQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/image-editor/-/image-editor-4.0.1.tgz",
+            "integrity": "sha512-FcC433I584CuuqCQH0kJHKl/qDQ1SCSUqAuZ34sKGoN1RPKsCRGeZrFjWQEtKd+C5q7cAz6Icp6AaVVP8ZKh2w==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "cropperjs": "^1.6.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/instagram": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/instagram/-/instagram-5.0.0.tgz",
-            "integrity": "sha512-uN7OB4Yt1mKM1yY+rzTMSmlcuBN/yMZItxpzOfeYm6d1pk3Fd0dFMIyikz/UWXdcJRv4/SyF9h2YLvGr9VAm9A==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/instagram/-/instagram-5.0.1.tgz",
+            "integrity": "sha512-Y3UD9e5UUgQ/EOimpAbwKvPYGwGBDyeaxIZyTIRrd6lODfCsVr4qOjWxH/2yJ/Eo+LSrh4IcWI71sb2T6LN0iA==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/locales": {
@@ -5704,34 +5833,34 @@
             }
         },
         "node_modules/@uppy/onedrive": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/onedrive/-/onedrive-5.0.0.tgz",
-            "integrity": "sha512-HT21O7rwenaMt+2Wrqs811k8tANKUYiuHkgeY/TvIbs2J2q51LWmPOxNUvToOxx01TT2y9mvUjvydapm/7O/+w==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/onedrive/-/onedrive-5.0.1.tgz",
+            "integrity": "sha512-jvTy7CE+M2SMRDH/b8RYB4vQb+BMloIdC1vEw3tNh9UyKpPWJjKCwSUk2sqCu1cT9Qv5bNgvU0/GOKxsZkv2tA==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/provider-views": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@uppy/provider-views/-/provider-views-5.0.1.tgz",
-            "integrity": "sha512-kwOjJgQUFr+cCZkKRpkAeql2fiVZKWYj/9FgbvF7abtwm9tVp9r80P10jyYLUpbCZyvAwvvomLEXBKm2Qdf+Dw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@uppy/provider-views/-/provider-views-5.0.2.tgz",
+            "integrity": "sha512-RaO/Gfq8kLA95s9n2kxAthiBcmLXocR+YiOhQ8H8DG1rA4aM2GllK7+b4KL1OLlg2tMHohs++qzaInCtb7br9g==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.1",
+                "@uppy/utils": "^7.0.2",
                 "classnames": "^2.2.6",
                 "nanoid": "^5.0.9",
                 "p-queue": "^8.0.0",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.1"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/provider-views/node_modules/nanoid": {
@@ -5753,37 +5882,37 @@
             }
         },
         "node_modules/@uppy/remote-sources": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/remote-sources/-/remote-sources-3.0.0.tgz",
-            "integrity": "sha512-Hums7HC0YVJP3WHI3674Fk5JYnpga6gDCBT2oK9sO2Cd0wK73VGSfzQRzDDrWxKu0updbunMMehccv4m7wNd4g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/remote-sources/-/remote-sources-3.0.1.tgz",
+            "integrity": "sha512-t9eBx7bRLVvb/lLmXhvDCr9AHZ0LicatdVEePjlRXtTfXWVX9pQ6Qh3j+Cnjg/Po0BDvfO1X5ZYETgwYSzRKeA==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/box": "^4.0.0",
-                "@uppy/dashboard": "^5.0.0",
-                "@uppy/dropbox": "^5.0.0",
-                "@uppy/facebook": "^5.0.0",
-                "@uppy/google-drive": "^5.0.0",
-                "@uppy/instagram": "^5.0.0",
-                "@uppy/onedrive": "^5.0.0",
-                "@uppy/unsplash": "^5.0.0",
-                "@uppy/url": "^5.0.0",
-                "@uppy/zoom": "^4.0.0"
+                "@uppy/box": "^4.0.1",
+                "@uppy/dashboard": "^5.0.2",
+                "@uppy/dropbox": "^5.0.1",
+                "@uppy/facebook": "^5.0.1",
+                "@uppy/google-drive": "^5.0.1",
+                "@uppy/instagram": "^5.0.1",
+                "@uppy/onedrive": "^5.0.1",
+                "@uppy/unsplash": "^5.0.1",
+                "@uppy/url": "^5.0.1",
+                "@uppy/zoom": "^4.0.1"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/screen-capture": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/screen-capture/-/screen-capture-5.0.0.tgz",
-            "integrity": "sha512-gH57mCnJfcPnvlN9FF/lOF7bw0D8Cdt9zQx4hxxkHtsVOtSkCy+j7nPknMuouTK1t1XNoiFM99SDzmPyK8AdPQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/screen-capture/-/screen-capture-5.0.1.tgz",
+            "integrity": "sha512-GBAOhku+6XILdgCW3KcWpvXFlX0o8yAZhe8mhN8AFEbQBUtxLZi63fcqfBRjKE0oHrV+4vuND1M5d1/P5UMYXg==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/store-default": {
@@ -5793,60 +5922,60 @@
             "license": "MIT"
         },
         "node_modules/@uppy/thumbnail-generator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/thumbnail-generator/-/thumbnail-generator-5.0.0.tgz",
-            "integrity": "sha512-dqnsVOpGR+QtpBKwXYEgiIy1cEl+wfiwm/411gwsAiaYITtEGePsXfTiYNFN/dkCVfrDqWw+r/MFTxRNXZKm9A==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/thumbnail-generator/-/thumbnail-generator-5.0.1.tgz",
+            "integrity": "sha512-kmRpZKGS+xCdXU66weLHZ30F8UYEW3U5amtZE8l/ZoDJf/mVevae0RBE8qQsEPXjs6IFH3MCgb4fZ/s/itc3QA==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "exifr": "^7.0.0"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/tus": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-5.0.0.tgz",
-            "integrity": "sha512-wGV8LgQAIdlMEQji91/glBy+TXlp6917z+nUCag4KhpW63WhQcd37xh34JjvQIf3IvaBa3Zjj37btQ3TL/aVeA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-5.0.1.tgz",
+            "integrity": "sha512-4BQA2UFjznXrJhmjsgT/m8WDThoSX2vxKZJH/aF1Xj4GmB46+a5kas6ttCsMDcPq918/sdRJsqCMGj1r4oXKLQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/utils": "^7.0.2",
                 "tus-js-client": "^4.2.3"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/unsplash": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/unsplash/-/unsplash-5.0.0.tgz",
-            "integrity": "sha512-cB0nwp5ZKfmjbs2rPEbQ8GkfJMQ2csNGy8Mncadbe91yv6cdPhEF9Z8OqaRGMc68/2PgXXKtsLTZyDJNurQ7Ig==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/unsplash/-/unsplash-5.0.1.tgz",
+            "integrity": "sha512-Iiy8904TQbM9FN0Sx1B8mXAP0iTS7464MxoJUJuMaHNQzPs6IlOs5In/6T0VX36OJ8hFmOG2hM3Q3xB2fGU0yQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/url/-/url-5.0.0.tgz",
-            "integrity": "sha512-82LBkkKwgUVhPSngfYY+aFLQjb5tnOc4IlqXSZoXV1XPb8Lsxd++gwg5EiOxQyNojJGTWPyZL1bPWn7qI5VNag==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/url/-/url-5.0.1.tgz",
+            "integrity": "sha512-hc7Sv/3p1aZIS0SebA10HO5T9022MWjr14NkNpdb1EfoeUzjjmr2xwQpnQNU1mo3UJFP4ULYWTlF3SH4cE8Deg==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/utils": "^7.0.2",
                 "nanoid": "^5.0.9",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/url/node_modules/nanoid": {
@@ -5868,9 +5997,9 @@
             }
         },
         "node_modules/@uppy/utils": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-7.0.1.tgz",
-            "integrity": "sha512-OLG5cbMYApwrj5VOeK4vEVOx0YtrsCMJKNqdA9LkFNIGWaF9KJPE6+P/MEvxgdAlnCZrF4Z7Gf/EuZF0gKMYJw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-7.0.2.tgz",
+            "integrity": "sha512-2fdtgwNTkLgh7yMmHN3ZztHaP/o/iXDSt5VAbvGG4tFFkRxaaDmSKAljglEle1+m1OamKQLjm8fIxfOqu/szng==",
             "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.21",
@@ -5878,18 +6007,18 @@
             }
         },
         "node_modules/@uppy/vue": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@uppy/vue/-/vue-3.0.2.tgz",
-            "integrity": "sha512-/VRkIyfB0W6fo2YrvCt5bWoRbMAG6ZTw3++gy46sMGeqVQhus/clHfJngrO4zlMzwRQH+DesDh3sSaWJiJajUw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@uppy/vue/-/vue-3.0.3.tgz",
+            "integrity": "sha512-VsE3m3tu/Y1C1Sb/ueEN+aj0uccYm30xRgNuWVaUIxpdXAIyAyjQXNuRl1uoij6pqs6h2e8cTuyNynOLCzay+g==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/components": "^1.0.1",
+                "@uppy/components": "^1.0.2",
                 "preact": "^10.5.13",
                 "shallow-equal": "^3.0.0"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.1",
-                "@uppy/dashboard": "^5.0.1",
+                "@uppy/core": "^5.0.2",
+                "@uppy/dashboard": "^5.0.2",
                 "vue": ">=3.0.0"
             },
             "peerDependenciesMeta": {
@@ -5899,32 +6028,32 @@
             }
         },
         "node_modules/@uppy/webcam": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/webcam/-/webcam-5.0.0.tgz",
-            "integrity": "sha512-dVKC253DqbUXidZTGehfCs9yu9QXHYLNd7J82yKNg+2vNc9/5NebCChEgWBxfdxlA4sbd2PPdHp+/qmGO6uqVQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/webcam/-/webcam-5.0.1.tgz",
+            "integrity": "sha512-zjt3g5E6g5NbufEtYBnK6IS5uBABQnuVixAiwfTYe9of1GkZJpOAe6qeg+zoRad0K/twt2YGqkGyhwzVL9ipuQ==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/utils": "^7.0.0",
+                "@uppy/utils": "^7.0.2",
                 "is-mobile": "^4.0.0",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@uppy/zoom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@uppy/zoom/-/zoom-4.0.0.tgz",
-            "integrity": "sha512-BWxV0CWS8G3C8fFcugAjRSB9Dqb8HmCkmOjcjMQSXPhI1uyaHCMJ2HC90Xe0m2p+kyXrubT/S7BRBvU3KLlfyw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@uppy/zoom/-/zoom-4.0.1.tgz",
+            "integrity": "sha512-O6zseYdZ4KP29n2o6htXth3P7tChyoNVaH43yeT1l9o3+ODTqcUJRdcYxi4vqs6jBUiCGAFhCVk0mETf0VkaLg==",
             "license": "MIT",
             "dependencies": {
-                "@uppy/companion-client": "^5.0.0",
-                "@uppy/provider-views": "^5.0.0",
-                "@uppy/utils": "^7.0.0",
+                "@uppy/companion-client": "^5.0.1",
+                "@uppy/provider-views": "^5.0.2",
+                "@uppy/utils": "^7.0.2",
                 "preact": "^10.5.13"
             },
             "peerDependencies": {
-                "@uppy/core": "^5.0.0"
+                "@uppy/core": "^5.0.2"
             }
         },
         "node_modules/@vee-validate/nuxt": {
@@ -5937,6 +6066,46 @@
                 "local-pkg": "^0.5.0",
                 "vee-validate": "4.15.1"
             }
+        },
+        "node_modules/@vee-validate/nuxt/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+            "license": "MIT",
+            "dependencies": {
+                "c12": "^3.2.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.0.7",
+                "ignore": "^7.0.5",
+                "jiti": "^2.5.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.2.0",
+                "mlly": "^1.8.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
+                "scule": "^1.3.0",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "unctx": "^2.4.1",
+                "unimport": "^5.2.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@vee-validate/nuxt/node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "license": "MIT"
         },
         "node_modules/@vee-validate/nuxt/node_modules/local-pkg": {
             "version": "0.5.1",
@@ -5954,7 +6123,7 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@vee-validate/nuxt/node_modules/pkg-types": {
+        "node_modules/@vee-validate/nuxt/node_modules/local-pkg/node_modules/pkg-types": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
             "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
@@ -5979,9 +6148,9 @@
             }
         },
         "node_modules/@vercel/nft": {
-            "version": "0.29.2",
-            "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.29.2.tgz",
-            "integrity": "sha512-A/Si4mrTkQqJ6EXJKv5EYCDQ3NL6nJXxG8VGXePsaiQigsomHYQC9xSpX8qGk7AEZk4b1ssbYIqJ0ISQQ7bfcA==",
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.30.1.tgz",
+            "integrity": "sha512-2mgJZv4AYBFkD/nJ4QmiX5Ymxi+AisPLPcS/KPXVqniyQNqKXX+wjieAbDXQP3HcogfEbpHoRMs49Cd4pfkk8g==",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/node-pre-gyp": "^2.0.0",
@@ -6014,41 +6183,51 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.3.tgz",
-            "integrity": "sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
+            "integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
             "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-beta.29"
+            },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "vue": "^3.2.25"
             }
         },
         "node_modules/@vitejs/plugin-vue-jsx": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-4.1.2.tgz",
-            "integrity": "sha512-4Rk0GdE0QCdsIkuMmWeg11gmM4x8UmTnZR/LWPm7QJ7+BsK4tq08udrN0isrrWqz5heFy9HLV/7bOLgFS8hUjA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.1.1.tgz",
+            "integrity": "sha512-uQkfxzlF8SGHJJVH966lFTdjM/lGcwJGzwAHpVqAPDD/QcsqoUGa+q31ox1BrUfi+FLP2ChVp7uLXE3DkHyDdQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.26.7",
-                "@babel/plugin-transform-typescript": "^7.26.7",
-                "@vue/babel-plugin-jsx": "^1.2.5"
+                "@babel/core": "^7.28.3",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/plugin-transform-typescript": "^7.28.0",
+                "@rolldown/pluginutils": "^1.0.0-beta.34",
+                "@vue/babel-plugin-jsx": "^1.5.0"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "vue": "^3.0.0"
             }
+        },
+        "node_modules/@vitejs/plugin-vue-jsx/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.38",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
+            "integrity": "sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==",
+            "license": "MIT"
         },
         "node_modules/@volar/language-core": {
             "version": "2.4.23",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
             "integrity": "sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/source-map": "2.4.23"
@@ -6058,14 +6237,13 @@
             "version": "2.4.23",
             "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz",
             "integrity": "sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
             "version": "2.4.23",
             "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
             "integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.23",
@@ -6074,20 +6252,22 @@
             }
         },
         "node_modules/@vue-macros/common": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-1.16.1.tgz",
-            "integrity": "sha512-Pn/AWMTjoMYuquepLZP813BIcq8DTZiNCoaceuNlvaYuOTd8DqBZWc5u0uOMQZMInwME1mdSmmBAcTluiV9Jtg==",
+            "version": "3.0.0-beta.16",
+            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.0.0-beta.16.tgz",
+            "integrity": "sha512-8O2gWxWFiaoNkk7PGi0+p7NPGe/f8xJ3/INUufvje/RZOs7sJvlI1jnR4lydtRFa/mU0ylMXUXXjSK0fHDEYTA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-sfc": "^3.5.13",
-                "ast-kit": "^1.4.0",
-                "local-pkg": "^1.0.0",
-                "magic-string-ast": "^0.7.0",
-                "pathe": "^2.0.2",
-                "picomatch": "^4.0.2"
+                "@vue/compiler-sfc": "^3.5.17",
+                "ast-kit": "^2.1.1",
+                "local-pkg": "^1.1.1",
+                "magic-string-ast": "^1.0.0",
+                "unplugin-utils": "^0.2.4"
             },
             "engines": {
-                "node": ">=16.14.0"
+                "node": ">=20.18.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/vue-macros"
             },
             "peerDependencies": {
                 "vue": "^2.7.0 || ^3.2.25"
@@ -6099,26 +6279,26 @@
             }
         },
         "node_modules/@vue/babel-helper-vue-transform-on": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.4.0.tgz",
-            "integrity": "sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.5.0.tgz",
+            "integrity": "sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==",
             "license": "MIT"
         },
         "node_modules/@vue/babel-plugin-jsx": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.4.0.tgz",
-            "integrity": "sha512-9zAHmwgMWlaN6qRKdrg1uKsBKHvnUU+Py+MOCTuYZBoZsopa90Di10QRjB+YPnVss0BZbG/H5XFwJY1fTxJWhA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.5.0.tgz",
+            "integrity": "sha512-mneBhw1oOqCd2247O0Yw/mRwC9jIGACAJUlawkmMBiNmL4dGA2eMzuNZVNqOUfYTa6vqmND4CtOPzmEEEqLKFw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.26.5",
-                "@babel/plugin-syntax-jsx": "^7.25.9",
-                "@babel/template": "^7.26.9",
-                "@babel/traverse": "^7.26.9",
-                "@babel/types": "^7.26.9",
-                "@vue/babel-helper-vue-transform-on": "1.4.0",
-                "@vue/babel-plugin-resolve-type": "1.4.0",
-                "@vue/shared": "^3.5.13"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.28.0",
+                "@babel/types": "^7.28.2",
+                "@vue/babel-helper-vue-transform-on": "1.5.0",
+                "@vue/babel-plugin-resolve-type": "1.5.0",
+                "@vue/shared": "^3.5.18"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
@@ -6130,16 +6310,16 @@
             }
         },
         "node_modules/@vue/babel-plugin-resolve-type": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.4.0.tgz",
-            "integrity": "sha512-4xqDRRbQQEWHQyjlYSgZsWj44KfiF6D+ktCuXyZ8EnVDYV3pztmXJDf1HveAjUAXxAnR8daCQT51RneWWxtTyQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.5.0.tgz",
+            "integrity": "sha512-Wm/60o+53JwJODm4Knz47dxJnLDJ9FnKnGZJbUUf8nQRAtt6P+undLUAVU3Ha33LxOJe6IPoifRQ6F/0RrU31w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.26.5",
-                "@babel/parser": "^7.26.9",
-                "@vue/compiler-sfc": "^3.5.13"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/parser": "^7.28.0",
+                "@vue/compiler-sfc": "^3.5.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sxzz"
@@ -6202,7 +6382,6 @@
             "version": "2.7.16",
             "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
             "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "de-indent": "^1.0.2",
@@ -6210,26 +6389,26 @@
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.2.tgz",
-            "integrity": "sha512-1syn558KhyN+chO5SjlZIwJ8bV/bQ1nOVTG66t2RbG66ZGekyiYNmRO7X9BJCXQqPsFHlnksqvPhce2qpzxFnA==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+            "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.7.2"
+                "@vue/devtools-kit": "^7.7.7"
             }
         },
         "node_modules/@vue/devtools-core": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.7.2.tgz",
-            "integrity": "sha512-lexREWj1lKi91Tblr38ntSsy6CvI8ba7u+jmwh2yruib/ltLUcsIzEjCnrkh1yYGGIKXbAuYV2tOG10fGDB9OQ==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.7.7.tgz",
+            "integrity": "sha512-9z9TLbfC+AjAi1PQyWX+OErjIaJmdFlbDHcD+cAMYKY6Bh5VlsAtCeGyRMrXwIlMEQPukvnWt3gZBLwTAIMKzQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.7.2",
-                "@vue/devtools-shared": "^7.7.2",
+                "@vue/devtools-kit": "^7.7.7",
+                "@vue/devtools-shared": "^7.7.7",
                 "mitt": "^3.0.1",
-                "nanoid": "^5.0.9",
-                "pathe": "^2.0.2",
-                "vite-hot-client": "^0.2.4"
+                "nanoid": "^5.1.0",
+                "pathe": "^2.0.3",
+                "vite-hot-client": "^2.0.4"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
@@ -6254,33 +6433,30 @@
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.2.tgz",
-            "integrity": "sha512-CY0I1JH3Z8PECbn6k3TqM1Bk9ASWxeMtTCvZr7vb+CHi+X/QwQm5F1/fPagraamKMAHVfuuCbdcnNg1A4CYVWQ==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
+            "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^7.7.2",
-                "birpc": "^0.2.19",
+                "@vue/devtools-shared": "^7.7.7",
+                "birpc": "^2.3.0",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
                 "perfect-debounce": "^1.0.0",
                 "speakingurl": "^14.0.1",
-                "superjson": "^2.2.1"
+                "superjson": "^2.2.2"
             }
         },
-        "node_modules/@vue/devtools-kit/node_modules/birpc": {
-            "version": "0.2.19",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
-            "integrity": "sha512-5WeXXAvTmitV1RqJFppT5QtUiz2p1mRSYU000Jkft5ZUCLJIk4uQriYNO50HknxKwM6jd8utNc66K1qGIwwWBQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
+        "node_modules/@vue/devtools-kit/node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "license": "MIT"
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.2.tgz",
-            "integrity": "sha512-uBFxnp8gwW2vD6FrJB8JZLUzVb6PNRG0B0jBnHsOH8uKyva2qINY8PTF5Te4QlTbMDqU5K6qtJDr6cNsKWhbOA==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
+            "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
             "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
@@ -6290,7 +6466,6 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.7.tgz",
             "integrity": "sha512-0sqqyqJ0Gn33JH3TdIsZLCZZ8Gr4kwlg8iYOnOrDDkJKSjFurlQY/bEFQx5zs7SX2C/bjMkmPYq/NiyY1fTOkw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.23",
@@ -6362,14 +6537,14 @@
             "license": "MIT"
         },
         "node_modules/@vueuse/core": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.6.0.tgz",
-            "integrity": "sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==",
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+            "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
             "license": "MIT",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.21",
-                "@vueuse/metadata": "13.6.0",
-                "@vueuse/shared": "13.6.0"
+                "@vueuse/metadata": "13.9.0",
+                "@vueuse/shared": "13.9.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -6379,18 +6554,18 @@
             }
         },
         "node_modules/@vueuse/metadata": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.6.0.tgz",
-            "integrity": "sha512-rnIH7JvU7NjrpexTsl2Iwv0V0yAx9cw7+clymjKuLSXG0QMcLD0LDgdNmXic+qL0SGvgSVPEpM9IDO/wqo1vkQ==",
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+            "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.6.0.tgz",
-            "integrity": "sha512-pDykCSoS2T3fsQrYqf9SyF0QXWHmcGPQ+qiOVjlYSzlWd9dgppB2bFSM1GgKKkt7uzn0BBMV3IbJsUfHG2+BCg==",
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+            "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -6400,9 +6575,9 @@
             }
         },
         "node_modules/abbrev": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
-            "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
             "license": "ISC",
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
@@ -6465,9 +6640,9 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -6493,22 +6668,12 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.7.tgz",
             "integrity": "sha512-wE7y3jmYeb0+h6mr5BOovuqhFv22O/MV9j5p0ndJsa7z1zJNPGQ4ph5pQk/kTTCWRC3xsA4SmtwmkzQO+7NCNg==",
-            "dev": true,
             "license": "MIT"
         },
-        "node_modules/ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/ansi-escapes": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.0.tgz",
+            "integrity": "sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6522,9 +6687,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -6534,9 +6699,9 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -6546,9 +6711,9 @@
             }
         },
         "node_modules/ansis": {
-            "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
-            "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
+            "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -6756,32 +6921,35 @@
             }
         },
         "node_modules/ast-kit": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.2.tgz",
-            "integrity": "sha512-lvGehj1XsrIoQrD5CfPduIzQbcpuX2EPjlk/vDMDQF9U9HLRB6WwMTdighj5n52hdhh8xg9VgPTU7Q25MuJ/rw==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
+            "integrity": "sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.9",
+                "@babel/parser": "^7.28.0",
                 "pathe": "^2.0.3"
             },
             "engines": {
-                "node": ">=16.14.0"
+                "node": ">=20.18.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/ast-walker-scope": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.6.2.tgz",
-            "integrity": "sha512-1UWOyC50xI3QZkRuDj6PqDtpm1oHWtYs+NQGwqL/2R11eN3Q81PHAHPM0SWW3BNQm53UDwS//Jv8L4CCVLM1bQ==",
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.2.tgz",
+            "integrity": "sha512-3pYeLyDZ6nJew9QeBhS4Nly02269Dkdk32+zdbbKmL6n4ZuaGorwwA+xx12xgOciA8BF1w9x+dlH7oUkFTW91w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.25.3",
-                "ast-kit": "^1.0.1"
+                "@babel/parser": "^7.28.3",
+                "ast-kit": "^2.1.2"
             },
             "engines": {
-                "node": ">=16.14.0"
+                "node": ">=20.18.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/async": {
@@ -6879,10 +7047,18 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-            "license": "Apache-2.0"
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
+            "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -6891,22 +7067,24 @@
             "license": "MIT"
         },
         "node_modules/bare-events": {
-            "version": "2.5.4",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-            "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
+            "integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
             "license": "Apache-2.0",
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.3.tgz",
-            "integrity": "sha512-1aGs5pRVLToMQ79elP+7cc0u0s/wXAzfBv/7hDloT7WFggLqECCas5qqPky7WHCFdsBH5WDq6sD4fAoz5sJbtA==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.4.tgz",
+            "integrity": "sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
-                "bare-stream": "^2.6.4"
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
             },
             "engines": {
                 "bare": ">=1.16.0"
@@ -6962,6 +7140,16 @@
                 }
             }
         },
+        "node_modules/bare-url": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
+            "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "bare-path": "^3.0.0"
+            }
+        },
         "node_modules/base-64": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
@@ -6974,6 +7162,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.5.tgz",
+            "integrity": "sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==",
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
             }
         },
         "node_modules/binary-extensions": {
@@ -6999,9 +7196,9 @@
             }
         },
         "node_modules/birpc": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.3.0.tgz",
-            "integrity": "sha512-ijbtkn/F3Pvzb6jHypHRyve2QApOCZDR25D/VnkY2G/lBNcXCTsnsCxgY4k4PkVB7zfwzYbY3O9Lcqe3xufS5g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.5.0.tgz",
+            "integrity": "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -7108,9 +7305,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.25.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-            "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+            "version": "4.26.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+            "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7127,9 +7324,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001737",
-                "electron-to-chromium": "^1.5.211",
-                "node-releases": "^2.0.19",
+                "baseline-browser-mapping": "^2.8.3",
+                "caniuse-lite": "^1.0.30001741",
+                "electron-to-chromium": "^1.5.218",
+                "node-releases": "^2.0.21",
                 "update-browserslist-db": "^1.1.3"
             },
             "bin": {
@@ -7241,22 +7439,22 @@
             }
         },
         "node_modules/c12": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/c12/-/c12-3.2.0.tgz",
-            "integrity": "sha512-ixkEtbYafL56E6HiFuonMm1ZjoKtIo7TH68/uiEq4DAwv9NcUX2nJ95F8TrbMeNjqIkZpruo3ojXQJ+MGG5gcQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.0.tgz",
+            "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.3",
                 "confbox": "^0.2.2",
                 "defu": "^6.1.4",
-                "dotenv": "^17.2.1",
+                "dotenv": "^17.2.2",
                 "exsolve": "^1.0.7",
                 "giget": "^2.0.0",
                 "jiti": "^2.5.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.2.0",
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
                 "rc9": "^2.1.2"
             },
             "peerDependencies": {
@@ -7266,24 +7464,6 @@
                 "magicast": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/c12/node_modules/confbox": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT"
-        },
-        "node_modules/c12/node_modules/dotenv": {
-            "version": "17.2.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-            "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
             }
         },
         "node_modules/cac": {
@@ -7457,9 +7637,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001741",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
-            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
+            "version": "1.0.30001743",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+            "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7637,17 +7817,17 @@
             }
         },
         "node_modules/cli-truncate": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.0.tgz",
+            "integrity": "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "slice-ansi": "^5.0.0",
-                "string-width": "^7.0.0"
+                "slice-ansi": "^7.1.0",
+                "string-width": "^8.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7707,12 +7887,6 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
         },
         "node_modules/cliui/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -7885,9 +8059,9 @@
             }
         },
         "node_modules/commander": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+            "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7910,9 +8084,9 @@
             "license": "MIT"
         },
         "node_modules/compatx": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/compatx/-/compatx-0.1.8.tgz",
-            "integrity": "sha512-jcbsEAR81Bt5s1qOFymBufmCbXCXbk0Ql+K5ouj6gCyx2yHlu6AgmGIi9HxfKixpUDO5bCFJUHQ5uM6ecbTebw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/compatx/-/compatx-0.2.0.tgz",
+            "integrity": "sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==",
             "license": "MIT"
         },
         "node_modules/compress-commons": {
@@ -8062,9 +8236,9 @@
             }
         },
         "node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
             "license": "MIT"
         },
         "node_modules/consola": {
@@ -8260,9 +8434,9 @@
             }
         },
         "node_modules/croner": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/croner/-/croner-9.0.0.tgz",
-            "integrity": "sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
+            "integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"
@@ -8340,9 +8514,9 @@
             }
         },
         "node_modules/css-select": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
@@ -8371,6 +8545,7 @@
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
             "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "mdn-data": "2.0.30",
                 "source-map-js": "^1.0.1"
@@ -8380,9 +8555,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
@@ -8417,13 +8592,13 @@
             "optional": true
         },
         "node_modules/cssnano": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.6.tgz",
-            "integrity": "sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
+            "integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
             "license": "MIT",
             "dependencies": {
-                "cssnano-preset-default": "^7.0.6",
-                "lilconfig": "^3.1.2"
+                "cssnano-preset-default": "^7.0.9",
+                "lilconfig": "^3.1.3"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -8433,63 +8608,63 @@
                 "url": "https://opencollective.com/cssnano"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.6.tgz",
-            "integrity": "sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.9.tgz",
+            "integrity": "sha512-tCD6AAFgYBOVpMBX41KjbvRh9c2uUjLXRyV7KHSIrwHiq5Z9o0TFfUCoM3TwVrRsRteN3sVXGNvjVNxYzkpTsA==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "css-declaration-sorter": "^7.2.0",
-                "cssnano-utils": "^5.0.0",
-                "postcss-calc": "^10.0.2",
-                "postcss-colormin": "^7.0.2",
-                "postcss-convert-values": "^7.0.4",
-                "postcss-discard-comments": "^7.0.3",
-                "postcss-discard-duplicates": "^7.0.1",
-                "postcss-discard-empty": "^7.0.0",
-                "postcss-discard-overridden": "^7.0.0",
-                "postcss-merge-longhand": "^7.0.4",
-                "postcss-merge-rules": "^7.0.4",
-                "postcss-minify-font-values": "^7.0.0",
-                "postcss-minify-gradients": "^7.0.0",
-                "postcss-minify-params": "^7.0.2",
-                "postcss-minify-selectors": "^7.0.4",
-                "postcss-normalize-charset": "^7.0.0",
-                "postcss-normalize-display-values": "^7.0.0",
-                "postcss-normalize-positions": "^7.0.0",
-                "postcss-normalize-repeat-style": "^7.0.0",
-                "postcss-normalize-string": "^7.0.0",
-                "postcss-normalize-timing-functions": "^7.0.0",
-                "postcss-normalize-unicode": "^7.0.2",
-                "postcss-normalize-url": "^7.0.0",
-                "postcss-normalize-whitespace": "^7.0.0",
-                "postcss-ordered-values": "^7.0.1",
-                "postcss-reduce-initial": "^7.0.2",
-                "postcss-reduce-transforms": "^7.0.0",
-                "postcss-svgo": "^7.0.1",
-                "postcss-unique-selectors": "^7.0.3"
+                "cssnano-utils": "^5.0.1",
+                "postcss-calc": "^10.1.1",
+                "postcss-colormin": "^7.0.4",
+                "postcss-convert-values": "^7.0.7",
+                "postcss-discard-comments": "^7.0.4",
+                "postcss-discard-duplicates": "^7.0.2",
+                "postcss-discard-empty": "^7.0.1",
+                "postcss-discard-overridden": "^7.0.1",
+                "postcss-merge-longhand": "^7.0.5",
+                "postcss-merge-rules": "^7.0.6",
+                "postcss-minify-font-values": "^7.0.1",
+                "postcss-minify-gradients": "^7.0.1",
+                "postcss-minify-params": "^7.0.4",
+                "postcss-minify-selectors": "^7.0.5",
+                "postcss-normalize-charset": "^7.0.1",
+                "postcss-normalize-display-values": "^7.0.1",
+                "postcss-normalize-positions": "^7.0.1",
+                "postcss-normalize-repeat-style": "^7.0.1",
+                "postcss-normalize-string": "^7.0.1",
+                "postcss-normalize-timing-functions": "^7.0.1",
+                "postcss-normalize-unicode": "^7.0.4",
+                "postcss-normalize-url": "^7.0.1",
+                "postcss-normalize-whitespace": "^7.0.1",
+                "postcss-ordered-values": "^7.0.2",
+                "postcss-reduce-initial": "^7.0.4",
+                "postcss-reduce-transforms": "^7.0.1",
+                "postcss-svgo": "^7.1.0",
+                "postcss-unique-selectors": "^7.0.4"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/cssnano-utils": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.0.tgz",
-            "integrity": "sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
+            "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/csso": {
@@ -8548,9 +8723,9 @@
             }
         },
         "node_modules/db0": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.1.tgz",
-            "integrity": "sha512-3RogPLE2LLq6t4YiFCREyl572aBjkfMvfwPyN51df00TbPbryL3XqBYuJ/j6mgPssPK8AKfYdLxizaO5UG10sA==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.2.tgz",
+            "integrity": "sha512-xzWNQ6jk/+NtdfLyXEipbX55dmDSeteLFt/ayF+wZUU5bzKgmrDOxmInUTbyVRp46YwnJdkDA1KhB7WIXFofJw==",
             "license": "MIT",
             "peerDependencies": {
                 "@electric-sql/pglite": "*",
@@ -8585,13 +8760,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
             "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -8806,6 +8980,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
@@ -8838,9 +9013,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/diff": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+            "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
@@ -8930,9 +9105,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.4.7",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-            "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+            "version": "17.2.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+            "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -8962,9 +9137,9 @@
             "license": "MIT"
         },
         "node_modules/earcut": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-            "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+            "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
             "license": "ISC"
         },
         "node_modules/eastasianwidth": {
@@ -8980,16 +9155,15 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.215",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
-            "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==",
+            "version": "1.5.221",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
+            "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-            "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-            "dev": true,
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/emoji-regex-xs": {
@@ -9011,18 +9185,18 @@
             }
         },
         "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+            "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -9058,19 +9232,13 @@
             }
         },
         "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
-        },
-        "node_modules/error-ex/node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "license": "MIT"
         },
         "node_modules/error-stack-parser-es": {
             "version": "1.0.5",
@@ -9106,9 +9274,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -9139,9 +9307,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
-            "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+            "version": "0.25.10",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+            "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -9151,32 +9319,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.8",
-                "@esbuild/android-arm": "0.25.8",
-                "@esbuild/android-arm64": "0.25.8",
-                "@esbuild/android-x64": "0.25.8",
-                "@esbuild/darwin-arm64": "0.25.8",
-                "@esbuild/darwin-x64": "0.25.8",
-                "@esbuild/freebsd-arm64": "0.25.8",
-                "@esbuild/freebsd-x64": "0.25.8",
-                "@esbuild/linux-arm": "0.25.8",
-                "@esbuild/linux-arm64": "0.25.8",
-                "@esbuild/linux-ia32": "0.25.8",
-                "@esbuild/linux-loong64": "0.25.8",
-                "@esbuild/linux-mips64el": "0.25.8",
-                "@esbuild/linux-ppc64": "0.25.8",
-                "@esbuild/linux-riscv64": "0.25.8",
-                "@esbuild/linux-s390x": "0.25.8",
-                "@esbuild/linux-x64": "0.25.8",
-                "@esbuild/netbsd-arm64": "0.25.8",
-                "@esbuild/netbsd-x64": "0.25.8",
-                "@esbuild/openbsd-arm64": "0.25.8",
-                "@esbuild/openbsd-x64": "0.25.8",
-                "@esbuild/openharmony-arm64": "0.25.8",
-                "@esbuild/sunos-x64": "0.25.8",
-                "@esbuild/win32-arm64": "0.25.8",
-                "@esbuild/win32-ia32": "0.25.8",
-                "@esbuild/win32-x64": "0.25.8"
+                "@esbuild/aix-ppc64": "0.25.10",
+                "@esbuild/android-arm": "0.25.10",
+                "@esbuild/android-arm64": "0.25.10",
+                "@esbuild/android-x64": "0.25.10",
+                "@esbuild/darwin-arm64": "0.25.10",
+                "@esbuild/darwin-x64": "0.25.10",
+                "@esbuild/freebsd-arm64": "0.25.10",
+                "@esbuild/freebsd-x64": "0.25.10",
+                "@esbuild/linux-arm": "0.25.10",
+                "@esbuild/linux-arm64": "0.25.10",
+                "@esbuild/linux-ia32": "0.25.10",
+                "@esbuild/linux-loong64": "0.25.10",
+                "@esbuild/linux-mips64el": "0.25.10",
+                "@esbuild/linux-ppc64": "0.25.10",
+                "@esbuild/linux-riscv64": "0.25.10",
+                "@esbuild/linux-s390x": "0.25.10",
+                "@esbuild/linux-x64": "0.25.10",
+                "@esbuild/netbsd-arm64": "0.25.10",
+                "@esbuild/netbsd-x64": "0.25.10",
+                "@esbuild/openbsd-arm64": "0.25.10",
+                "@esbuild/openbsd-x64": "0.25.10",
+                "@esbuild/openharmony-arm64": "0.25.10",
+                "@esbuild/sunos-x64": "0.25.10",
+                "@esbuild/win32-arm64": "0.25.10",
+                "@esbuild/win32-ia32": "0.25.10",
+                "@esbuild/win32-x64": "0.25.10"
             }
         },
         "node_modules/escalade": {
@@ -9965,9 +10133,9 @@
             "license": "MIT"
         },
         "node_modules/fast-npm-meta": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/fast-npm-meta/-/fast-npm-meta-0.3.1.tgz",
-            "integrity": "sha512-W9gVhqRyz2O3j20I0nFmYEyaMC/046oaMRxxAQ0w6noakfbhpLmlIXmnnqSOmVVuJZ6x5hOPVwlv7PocuawZsw==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/fast-npm-meta/-/fast-npm-meta-0.4.6.tgz",
+            "integrity": "sha512-zbBBOAOlzxfrU4WSnbCHk/nR6Vf32lSEPxDEvNOR08Z5DSZ/A6qJu0rqrHVcexBTd1hc2gim998xnqF/R1PuEw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -10198,12 +10366,12 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/fs-constants": {
@@ -10301,9 +10469,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.1.tgz",
-            "integrity": "sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10398,9 +10566,9 @@
             }
         },
         "node_modules/git-up": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.0.1.tgz",
-            "integrity": "sha512-2XFu1uNZMSjkyetaF+8rqn6P0XqpMq/C+2ycjI6YwrIKcszZ5/WR4UubxjN0lILOKqLkLaHDaCr2B6fP1cke6g==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+            "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
             "license": "MIT",
             "dependencies": {
                 "is-ssh": "^1.4.0",
@@ -10408,12 +10576,12 @@
             }
         },
         "node_modules/git-url-parse": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.0.1.tgz",
-            "integrity": "sha512-mcD36GrhAzX5JVOsIO52qNpgRyFzYWRbU1VSRFCvJt1IJvqfvH427wWw/CFqkWvjVPtdG5VTx4MKUeC5GeFPDQ==",
+            "version": "16.1.0",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+            "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
             "license": "MIT",
             "dependencies": {
-                "git-up": "^8.0.0"
+                "git-up": "^8.1.0"
             }
         },
         "node_modules/github-from-package": {
@@ -10477,9 +10645,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-            "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -10680,7 +10848,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "he": "bin/he"
@@ -10768,9 +10935,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
         "node_modules/http-errors": {
@@ -10785,6 +10952,15 @@
                 "statuses": "2.0.1",
                 "toidentifier": "1.0.1"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-errors/node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -10926,16 +11102,16 @@
             }
         },
         "node_modules/impound": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/impound/-/impound-0.2.2.tgz",
-            "integrity": "sha512-9CNg+Ly8QjH4FwCUoE9nl1zeqY1NPK1s1P6Btp4L8lJxn8oZLN/0p6RZhitnyEL0BnVWrcVPfbs0Q3x+O/ucHg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/impound/-/impound-1.0.0.tgz",
+            "integrity": "sha512-8lAJ+1Arw2sMaZ9HE2ZmL5zOcMnt18s6+7Xqgq2aUVy4P1nlzAyPtzCDxsk51KVFwHEEdc6OWvUyqwHwhRYaug==",
             "license": "MIT",
             "dependencies": {
-                "@rollup/pluginutils": "^5.1.4",
-                "mlly": "^1.7.4",
-                "mocked-exports": "^0.1.0",
+                "exsolve": "^1.0.5",
+                "mocked-exports": "^0.1.1",
                 "pathe": "^2.0.3",
-                "unplugin": "^2.2.0"
+                "unplugin": "^2.3.2",
+                "unplugin-utils": "^0.2.4"
             }
         },
         "node_modules/imurmurhash": {
@@ -10954,18 +11130,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/index-to-position": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.0.0.tgz",
-            "integrity": "sha512-sCO7uaLVhRJ25vz1o8s9IFM3nVS4DkuQnyjMwiQPKvQuBYBDmb8H7zx8ki7nVh4HJQOdVWebyvLE0qt+clruxA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -10999,12 +11163,12 @@
             }
         },
         "node_modules/ioredis": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.0.tgz",
-            "integrity": "sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+            "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
             "license": "MIT",
             "dependencies": {
-                "@ioredis/commands": "^1.1.1",
+                "@ioredis/commands": "^1.3.0",
                 "cluster-key-slot": "^1.1.0",
                 "debug": "^4.3.4",
                 "denque": "^2.1.0",
@@ -11067,11 +11231,10 @@
             }
         },
         "node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "license": "MIT",
-            "optional": true
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "license": "MIT"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -11141,13 +11304,16 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.1"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11231,9 +11397,9 @@
             "license": "MIT"
         },
         "node_modules/is-network-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
-            "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.2.0.tgz",
+            "integrity": "sha512-32jdpRpJo8SeL7zOuBJbMLz/VTw9mDpTvcKzzR8DkXWsJbbE60gdiX8YOd0UAV6b8Skt+CMytzfgVVIRFidn0Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=16"
@@ -11438,9 +11604,9 @@
             }
         },
         "node_modules/js-base64": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+            "version": "3.7.8",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+            "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
             "license": "BSD-3-Clause"
         },
         "node_modules/js-confetti": {
@@ -11448,15 +11614,6 @@
             "resolved": "https://registry.npmjs.org/js-confetti/-/js-confetti-0.13.1.tgz",
             "integrity": "sha512-Kau3apum0zYIvELfZv0lL5VY7dvzpbKi4Oq0XdfjDKdNZc/O+IeGRyLEej7GJ/1APbASvb+ZTWDxmTxxSFkTOg==",
             "license": "MIT"
-        },
-        "node_modules/js-levenshtein": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -11544,9 +11701,9 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11630,9 +11787,9 @@
             "license": "MIT"
         },
         "node_modules/koa": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-            "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
+            "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11771,6 +11928,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/koa/node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/koa/node_modules/http-errors": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -11809,13 +11976,13 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
-            "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+            "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
             "license": "MIT",
             "dependencies": {
-                "picocolors": "^1.0.0",
-                "shell-quote": "^1.8.1"
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.3"
             }
         },
         "node_modules/lazystream": {
@@ -11964,13 +12131,13 @@
             "license": "MIT"
         },
         "node_modules/listr2": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.3.tgz",
-            "integrity": "sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
+            "integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cli-truncate": "^4.0.0",
+                "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
                 "eventemitter3": "^5.0.1",
                 "log-update": "^6.1.0",
@@ -11998,14 +12165,14 @@
             }
         },
         "node_modules/local-pkg": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-            "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+            "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
             "license": "MIT",
             "dependencies": {
                 "mlly": "^1.7.4",
-                "pkg-types": "^2.0.1",
-                "quansync": "^0.2.8"
+                "pkg-types": "^2.3.0",
+                "quansync": "^0.2.11"
             },
             "engines": {
                 "node": ">=14"
@@ -12153,39 +12320,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/slice-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "is-fullwidth-code-point": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -12207,6 +12341,30 @@
                 "node": ">=10"
             }
         },
+        "node_modules/magic-regexp": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.10.0.tgz",
+            "integrity": "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==",
+            "license": "MIT",
+            "dependencies": {
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12",
+                "mlly": "^1.7.2",
+                "regexp-tree": "^0.1.27",
+                "type-level-regexp": "~0.1.17",
+                "ufo": "^1.5.4",
+                "unplugin": "^2.0.0"
+            }
+        },
+        "node_modules/magic-regexp/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.19",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -12217,15 +12375,15 @@
             }
         },
         "node_modules/magic-string-ast": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-0.7.1.tgz",
-            "integrity": "sha512-ub9iytsEbT7Yw/Pd29mSo/cNQpaEu67zR1VVcXDiYjSFwzeBxNdTd0FMnSslLQXiRj8uGPzwsaoefrMD5XAmdw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.2.tgz",
+            "integrity": "sha512-8ngQgLhcT0t3YBdn9CGkZqCYlvwW9pm7aWJwd7AxseVWf1RU8ZHCQvG1mt3N5vvUme+pXTcHB8G/7fE666U8Vw==",
             "license": "MIT",
             "dependencies": {
                 "magic-string": "^0.30.17"
             },
             "engines": {
-                "node": ">=16.14.0"
+                "node": ">=20.18.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sxzz"
@@ -12329,7 +12487,8 @@
             "version": "2.0.30",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "optional": true
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -12430,9 +12589,9 @@
             }
         },
         "node_modules/mime": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
-            "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+            "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
             "funding": [
                 "https://github.com/sponsors/broofa"
             ],
@@ -12566,13 +12725,12 @@
             }
         },
         "node_modules/minizlib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
-            "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+            "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
             "license": "MIT",
             "dependencies": {
-                "minipass": "^7.0.4",
-                "rimraf": "^5.0.5"
+                "minipass": "^7.1.2"
             },
             "engines": {
                 "node": ">= 18"
@@ -12618,6 +12776,12 @@
                 "ufo": "^1.6.1"
             }
         },
+        "node_modules/mlly/node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "license": "MIT"
+        },
         "node_modules/mlly/node_modules/pkg-types": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -12654,7 +12818,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
             "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/murmurhash-js": {
@@ -12682,9 +12845,9 @@
             "license": "MIT"
         },
         "node_modules/nano-spawn": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
-            "integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
+            "integrity": "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12757,90 +12920,88 @@
             }
         },
         "node_modules/nitropack": {
-            "version": "2.11.7",
-            "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.11.7.tgz",
-            "integrity": "sha512-ghqLa3Q4X9qaQiUyspWxxoU1fY2nwfSJqhOH+COqyCp7Vgj4oM1EM1L0YNSQUF16T2tAoOWg8woXGq0EH5Y6wQ==",
+            "version": "2.12.6",
+            "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.12.6.tgz",
+            "integrity": "sha512-DEq31s0SP4/Z5DIoVBRo9DbWFPWwIoYD4cQMEz7eE+iJMiAP+1k9A3B9kcc6Ihc0jDJmfUcHYyh6h2XlynCx6g==",
             "license": "MIT",
             "dependencies": {
                 "@cloudflare/kv-asset-handler": "^0.4.0",
-                "@netlify/functions": "^3.0.2",
                 "@rollup/plugin-alias": "^5.1.1",
-                "@rollup/plugin-commonjs": "^28.0.3",
+                "@rollup/plugin-commonjs": "^28.0.6",
                 "@rollup/plugin-inject": "^5.0.5",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.1",
                 "@rollup/plugin-replace": "^6.0.2",
                 "@rollup/plugin-terser": "^0.4.4",
-                "@vercel/nft": "^0.29.2",
+                "@vercel/nft": "^0.30.1",
                 "archiver": "^7.0.1",
-                "c12": "^3.0.2",
+                "c12": "^3.2.0",
                 "chokidar": "^4.0.3",
                 "citty": "^0.1.6",
-                "compatx": "^0.1.8",
-                "confbox": "^0.2.1",
+                "compatx": "^0.2.0",
+                "confbox": "^0.2.2",
                 "consola": "^3.4.2",
                 "cookie-es": "^2.0.0",
-                "croner": "^9.0.0",
-                "crossws": "^0.3.4",
-                "db0": "^0.3.1",
+                "croner": "^9.1.0",
+                "crossws": "^0.3.5",
+                "db0": "^0.3.2",
                 "defu": "^6.1.4",
-                "destr": "^2.0.3",
+                "destr": "^2.0.5",
                 "dot-prop": "^9.0.0",
-                "esbuild": "^0.25.1",
+                "esbuild": "^0.25.9",
                 "escape-string-regexp": "^5.0.0",
                 "etag": "^1.8.1",
-                "exsolve": "^1.0.4",
+                "exsolve": "^1.0.7",
                 "globby": "^14.1.0",
                 "gzip-size": "^7.0.0",
-                "h3": "^1.15.1",
+                "h3": "^1.15.4",
                 "hookable": "^5.5.3",
                 "httpxy": "^0.1.7",
-                "ioredis": "^5.6.0",
-                "jiti": "^2.4.2",
+                "ioredis": "^5.7.0",
+                "jiti": "^2.5.1",
                 "klona": "^2.0.6",
                 "knitwork": "^1.2.0",
                 "listhen": "^1.9.0",
-                "magic-string": "^0.30.17",
+                "magic-string": "^0.30.19",
                 "magicast": "^0.3.5",
-                "mime": "^4.0.6",
-                "mlly": "^1.7.4",
-                "node-fetch-native": "^1.6.6",
-                "node-mock-http": "^1.0.0",
+                "mime": "^4.0.7",
+                "mlly": "^1.8.0",
+                "node-fetch-native": "^1.6.7",
+                "node-mock-http": "^1.0.3",
                 "ofetch": "^1.4.1",
                 "ohash": "^2.0.11",
-                "openapi-typescript": "^7.6.1",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.1.0",
-                "pretty-bytes": "^6.1.1",
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
+                "pretty-bytes": "^7.0.1",
                 "radix3": "^1.1.2",
-                "rollup": "^4.36.0",
-                "rollup-plugin-visualizer": "^5.14.0",
+                "rollup": "^4.50.1",
+                "rollup-plugin-visualizer": "^6.0.3",
                 "scule": "^1.3.0",
-                "semver": "^7.7.1",
+                "semver": "^7.7.2",
                 "serve-placeholder": "^2.0.2",
-                "serve-static": "^1.16.2",
-                "source-map": "^0.7.4",
-                "std-env": "^3.8.1",
-                "ufo": "^1.5.4",
-                "ultrahtml": "^1.5.3",
+                "serve-static": "^2.2.0",
+                "source-map": "^0.7.6",
+                "std-env": "^3.9.0",
+                "ufo": "^1.6.1",
+                "ultrahtml": "^1.6.0",
                 "uncrypto": "^0.1.3",
                 "unctx": "^2.4.1",
-                "unenv": "^2.0.0-rc.15",
-                "unimport": "^4.1.2",
-                "unplugin-utils": "^0.2.4",
-                "unstorage": "^1.15.0",
+                "unenv": "^2.0.0-rc.21",
+                "unimport": "^5.2.0",
+                "unplugin-utils": "^0.3.0",
+                "unstorage": "^1.17.1",
                 "untyped": "^2.0.0",
-                "unwasm": "^0.3.9",
-                "youch": "^4.1.0-beta.6",
-                "youch-core": "^0.3.2"
+                "unwasm": "^0.3.11",
+                "youch": "^4.1.0-beta.11",
+                "youch-core": "^0.3.3"
             },
             "bin": {
                 "nitro": "dist/cli/index.mjs",
                 "nitropack": "dist/cli/index.mjs"
             },
             "engines": {
-                "node": "^16.11.0 || >=17.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
                 "xml2js": "^0.6.2"
@@ -12850,12 +13011,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/nitropack/node_modules/confbox": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
-            "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==",
-            "license": "MIT"
         },
         "node_modules/nitropack/node_modules/cookie-es": {
             "version": "2.0.0",
@@ -12873,6 +13028,34 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nitropack/node_modules/pretty-bytes": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.0.1.tgz",
+            "integrity": "sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nitropack/node_modules/unplugin-utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.0.tgz",
+            "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
+            "license": "MIT",
+            "dependencies": {
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/no-scroll": {
@@ -12921,9 +13104,9 @@
             }
         },
         "node_modules/node-fetch-native": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-            "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
             "license": "MIT"
         },
         "node_modules/node-forge": {
@@ -12947,15 +13130,15 @@
             }
         },
         "node_modules/node-mock-http": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.2.tgz",
-            "integrity": "sha512-zWaamgDUdo9SSLw47we78+zYw/bDr5gH8pH7oRRs8V3KmBtu8GLgGIbV2p/gRPd3LWpEOpjQj7X1FOU3VFMJ8g==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
+            "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+            "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
             "license": "MIT"
         },
         "node_modules/nopt": {
@@ -13058,81 +13241,81 @@
             }
         },
         "node_modules/nuxt": {
-            "version": "3.16.1",
-            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.16.1.tgz",
-            "integrity": "sha512-V0odAW9Yo8s58yGnSy0RuX+rQwz0wtQp3eOgMTsh1YDDZdIIYZmAlZaLypNeieO/mbmvOOUcnuRyIGIRrF4+5A==",
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.19.2.tgz",
+            "integrity": "sha512-z4ouGRMOWqZ1xaZ+HdRBRVlZcKSoDBpRxQ30GJ2dllraZMC/gNpTGuY32H3xP5b4R29b8uYcK+B8LFQoRHpO8A==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/cli": "^3.23.1",
+                "@nuxt/cli": "^3.28.0",
                 "@nuxt/devalue": "^2.0.2",
-                "@nuxt/devtools": "^2.3.0",
-                "@nuxt/kit": "3.16.1",
-                "@nuxt/schema": "3.16.1",
+                "@nuxt/devtools": "^2.6.3",
+                "@nuxt/kit": "3.19.2",
+                "@nuxt/schema": "3.19.2",
                 "@nuxt/telemetry": "^2.6.6",
-                "@nuxt/vite-builder": "3.16.1",
-                "@oxc-parser/wasm": "^0.60.0",
-                "@unhead/vue": "^2.0.0-rc.13",
-                "@vue/shared": "^3.5.13",
-                "c12": "^3.0.2",
+                "@nuxt/vite-builder": "3.19.2",
+                "@unhead/vue": "^2.0.14",
+                "@vue/shared": "^3.5.21",
+                "c12": "^3.2.0",
                 "chokidar": "^4.0.3",
-                "compatx": "^0.1.8",
+                "compatx": "^0.2.0",
                 "consola": "^3.4.2",
                 "cookie-es": "^2.0.0",
                 "defu": "^6.1.4",
-                "destr": "^2.0.3",
-                "devalue": "^5.1.1",
+                "destr": "^2.0.5",
+                "devalue": "^5.3.2",
                 "errx": "^0.1.0",
-                "esbuild": "^0.25.1",
+                "esbuild": "^0.25.9",
                 "escape-string-regexp": "^5.0.0",
                 "estree-walker": "^3.0.3",
-                "exsolve": "^1.0.4",
-                "globby": "^14.1.0",
-                "h3": "^1.15.1",
+                "exsolve": "^1.0.7",
+                "h3": "^1.15.4",
                 "hookable": "^5.5.3",
-                "ignore": "^7.0.3",
-                "impound": "^0.2.2",
-                "jiti": "^2.4.2",
+                "ignore": "^7.0.5",
+                "impound": "^1.0.0",
+                "jiti": "^2.5.1",
                 "klona": "^2.0.6",
                 "knitwork": "^1.2.0",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
+                "magic-string": "^0.30.19",
+                "mlly": "^1.8.0",
                 "mocked-exports": "^0.1.1",
                 "nanotar": "^0.2.0",
-                "nitropack": "^2.11.7",
-                "nypm": "^0.6.0",
+                "nitropack": "^2.12.5",
+                "nypm": "^0.6.1",
                 "ofetch": "^1.4.1",
                 "ohash": "^2.0.11",
                 "on-change": "^5.0.1",
-                "oxc-parser": "^0.56.3",
+                "oxc-minify": "^0.87.0",
+                "oxc-parser": "^0.87.0",
+                "oxc-transform": "^0.87.0",
+                "oxc-walker": "^0.5.2",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.1.0",
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
                 "radix3": "^1.1.2",
                 "scule": "^1.3.0",
-                "semver": "^7.7.1",
-                "std-env": "^3.8.1",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "0.2.12",
-                "ufo": "^1.5.4",
-                "ultrahtml": "^1.5.3",
+                "semver": "^7.7.2",
+                "std-env": "^3.9.0",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.6.1",
+                "ultrahtml": "^1.6.0",
                 "uncrypto": "^0.1.3",
                 "unctx": "^2.4.1",
-                "unimport": "^4.1.2",
-                "unplugin": "^2.2.1",
-                "unplugin-vue-router": "^0.12.0",
-                "unstorage": "^1.15.0",
+                "unimport": "^5.2.0",
+                "unplugin": "^2.3.10",
+                "unplugin-vue-router": "^0.15.0",
+                "unstorage": "^1.17.1",
                 "untyped": "^2.0.0",
-                "vue": "^3.5.13",
-                "vue-bundle-renderer": "^2.1.1",
+                "vue": "^3.5.21",
+                "vue-bundle-renderer": "^2.1.2",
                 "vue-devtools-stub": "^0.1.0",
-                "vue-router": "^4.5.0"
+                "vue-router": "^4.5.1"
             },
             "bin": {
                 "nuxi": "bin/nuxt.mjs",
                 "nuxt": "bin/nuxt.mjs"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
                 "@parcel/watcher": "^2.1.0",
@@ -13148,9 +13331,9 @@
             }
         },
         "node_modules/nuxt-auth-sanctum": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/nuxt-auth-sanctum/-/nuxt-auth-sanctum-0.6.6.tgz",
-            "integrity": "sha512-pD3inouKL88We6ULq9YvjWxgg3WBphubD64jggDzK1PhD4aZ7mzkasArkKhHfFmHDjMFVGX1mrlzlpoULoKb9g==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/nuxt-auth-sanctum/-/nuxt-auth-sanctum-0.6.7.tgz",
+            "integrity": "sha512-LLhgTW/ITqliyxMxCxFvH1+1Y2U0Cs+uk1X55pM73i8a83VeW8yaZM1jLBvj35ugz+cN6YRwpSYsMu8VqRUXCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13160,185 +13343,68 @@
             }
         },
         "node_modules/nuxt-link-checker": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/nuxt-link-checker/-/nuxt-link-checker-4.3.1.tgz",
-            "integrity": "sha512-ntsKKLThlDs/Y9aoBgfld+uwJw0lu3CqDe6cgZDEDTVu55HcgXT9CJV3f/DI5+FvprJnLfnmNY7/cMMcLLHWeg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/nuxt-link-checker/-/nuxt-link-checker-4.3.2.tgz",
+            "integrity": "sha512-ehEeoe1OFW2r9ZC7DCneYsk2eupyi5udLpbqbTtJOiqoCddbDZ8/bv7k6kBwbQAAyZPJFptGhwas8n4hUUY3Qg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "^2.5.0",
-                "@nuxt/kit": "^3.17.5",
-                "@vueuse/core": "^13.3.0",
+                "@nuxt/devtools-kit": "^2.6.3",
+                "@nuxt/kit": "^4.1.2",
+                "@vueuse/core": "^13.9.0",
                 "consola": "^3.4.2",
                 "diff": "^8.0.2",
                 "fuse.js": "^7.1.0",
-                "magic-string": "^0.30.17",
-                "nuxt-site-config": "^3.2.0",
+                "magic-string": "^0.30.19",
+                "nuxt-site-config": "^3.2.5",
                 "ofetch": "^1.4.1",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.1.0",
+                "pkg-types": "^2.3.0",
                 "radix3": "^1.1.2",
-                "sirv": "^3.0.1",
+                "sirv": "^3.0.2",
                 "std-env": "^3.9.0",
                 "ufo": "^1.6.1",
                 "ultrahtml": "^1.6.0",
-                "unstorage": "^1.16.0"
+                "unstorage": "^1.17.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
             }
         },
-        "node_modules/nuxt-link-checker/node_modules/@nuxt/devtools-kit": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.6.2.tgz",
-            "integrity": "sha512-esErdMQ0u3wXXogKQ3IE2m0fxv52w6CzPsfsXF4o5ZVrUQrQaH58ygupDAQTYdlGTgtqmEA6KkHTGG5cM6yxeg==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^3.17.6",
-                "execa": "^8.0.1"
-            },
-            "peerDependencies": {
-                "vite": ">=6.0"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/diff": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-            "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/nuxt-link-checker/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/nuxt-og-image": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-5.1.9.tgz",
-            "integrity": "sha512-VsGpaV/Q9mhr6YhTTXsxiPbE5rucrW0dNmfssxaWEF4rKhnpKBh8U2C1QK8iddo7Gg2lqD2L9zcBe4GsHl8X8w==",
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-5.1.11.tgz",
+            "integrity": "sha512-LnioM0JsfrSYPo/4TgPBu+ncI6QNCejs0FVu/f/SLeygwrh3senm9MvlBi1tldE1AU0J7030uO8UekOlvFPPXQ==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/devtools-kit": "^2.6.2",
-                "@nuxt/kit": "^3.17.6",
+                "@nuxt/devtools-kit": "^2.6.3",
+                "@nuxt/kit": "^4.1.2",
                 "@resvg/resvg-js": "^2.6.2",
                 "@resvg/resvg-wasm": "^2.6.2",
-                "@unocss/core": "^66.3.2",
-                "@unocss/preset-wind3": "^66.3.2",
+                "@unocss/core": "^66.5.1",
+                "@unocss/preset-wind3": "^66.5.1",
                 "chrome-launcher": "^1.2.0",
                 "consola": "^3.4.2",
                 "defu": "^6.1.4",
                 "execa": "^9.6.0",
                 "image-size": "^2.0.2",
-                "magic-string": "^0.30.17",
+                "magic-string": "^0.30.19",
                 "mocked-exports": "^0.1.1",
-                "nuxt-site-config": "^3.2.2",
-                "nypm": "^0.6.0",
+                "nuxt-site-config": "^3.2.5",
+                "nypm": "^0.6.2",
                 "ofetch": "^1.4.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "playwright-core": "^1.53.2",
+                "pkg-types": "^2.3.0",
+                "playwright-core": "^1.55.0",
                 "radix3": "^1.1.2",
                 "satori": "^0.15.2",
                 "satori-html": "^0.3.2",
-                "sirv": "^3.0.1",
+                "sirv": "^3.0.2",
                 "std-env": "^3.9.0",
                 "strip-literal": "^3.0.0",
                 "ufo": "^1.6.1",
-                "unplugin": "^2.3.5",
-                "unwasm": "^0.3.9",
+                "unplugin": "^2.3.10",
+                "unwasm": "^0.3.11",
                 "yoga-wasm-web": "^0.3.3"
             },
             "engines": {
@@ -13352,75 +13418,6 @@
                 "unstorage": "^1.15.0"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/@nuxt/devtools-kit": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.6.2.tgz",
-            "integrity": "sha512-esErdMQ0u3wXXogKQ3IE2m0fxv52w6CzPsfsXF4o5ZVrUQrQaH58ygupDAQTYdlGTgtqmEA6KkHTGG5cM6yxeg==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^3.17.6",
-                "execa": "^8.0.1"
-            },
-            "peerDependencies": {
-                "vite": ">=6.0"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/@nuxt/devtools-kit/node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/nuxt-og-image/node_modules/@sindresorhus/merge-streams": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -13431,27 +13428,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
             }
         },
         "node_modules/nuxt-og-image/node_modules/execa": {
@@ -13480,7 +13456,7 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/execa/node_modules/get-stream": {
+        "node_modules/nuxt-og-image/node_modules/get-stream": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
             "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
@@ -13496,7 +13472,7 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/execa/node_modules/human-signals": {
+        "node_modules/nuxt-og-image/node_modules/human-signals": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
             "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
@@ -13505,7 +13481,19 @@
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/execa/node_modules/is-stream": {
+        "node_modules/nuxt-og-image/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nuxt-og-image/node_modules/is-stream": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
             "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
@@ -13517,7 +13505,7 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/execa/node_modules/npm-run-path": {
+        "node_modules/nuxt-og-image/node_modules/npm-run-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
             "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
@@ -13528,30 +13516,6 @@
             },
             "engines": {
                 "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/execa/node_modules/strip-final-newline": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-og-image/node_modules/is-plain-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -13569,20 +13533,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+        "node_modules/nuxt-og-image/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
             "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18"
             },
             "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/nuxt-og-image/node_modules/unicorn-magic": {
@@ -13597,35 +13557,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nuxt-og-image/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/nuxt-primevue": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/nuxt-primevue/-/nuxt-primevue-3.0.0.tgz",
             "integrity": "sha512-MC3ubLTF0hzUEsQ2gYzzlzaW1gXN9/wrpbWnS9xwK47TWw1gcfim8idu5mcOx+l66CPAtTLOR1QJahkDc4m9XA==",
+            "deprecated": "This package has been deprecated. Please use @primevue/nuxt-module instead.",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13634,43 +13570,11 @@
                 "primevue": "^3.51.0"
             }
         },
-        "node_modules/nuxt-primevue/node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+        "node_modules/nuxt-primevue/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/nuxt-schema-org": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/nuxt-schema-org/-/nuxt-schema-org-5.0.6.tgz",
-            "integrity": "sha512-ssNYeb/bARsTgbkIB+EdpXkwtX/+TKb/3vd0KxE6xuu60A4h4OCNwUnJhVhkpaLa+ry8nKDk30FUpgWdJyzNHA==",
-            "license": "MIT",
-            "dependencies": {
-                "@nuxt/kit": "^3.17.5",
-                "@unhead/schema-org": "^2.0.11",
-                "defu": "^6.1.4",
-                "nuxt-site-config": "^3.2.2",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.1.0",
-                "sirv": "^3.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/harlan-zw"
-            },
-            "peerDependencies": {
-                "@unhead/vue": "^2.0.7"
-            },
-            "peerDependenciesMeta": {
-                "@unhead/vue": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/nuxt-schema-org/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.2.0",
@@ -13683,14 +13587,15 @@
                 "jiti": "^2.5.1",
                 "klona": "^2.0.6",
                 "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
+                "mlly": "^1.8.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
                 "scule": "^1.3.0",
                 "semver": "^7.7.2",
                 "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
+                "tinyglobby": "^0.2.15",
                 "ufo": "^1.6.1",
                 "unctx": "^2.4.1",
                 "unimport": "^5.2.0",
@@ -13700,121 +13605,71 @@
                 "node": ">=18.12.0"
             }
         },
-        "node_modules/nuxt-schema-org/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/nuxt-primevue/node_modules/@nuxt/kit/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
-        "node_modules/nuxt-schema-org/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+        "node_modules/nuxt-primevue/node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nuxt-schema-org": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/nuxt-schema-org/-/nuxt-schema-org-5.0.9.tgz",
+            "integrity": "sha512-k0i3h9WJYz0ikLtxLky0Ip0Cbr+P98I2tV7zWu7kZNUSi47PagM/Qd7/RA2jf0sq4VC9JwQUDtjDp7r3u4S8kw==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/nuxt-schema-org/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/nuxt-schema-org/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
+                "@nuxt/kit": "^4.1.2",
+                "@unhead/schema-org": "^2.0.14",
+                "defu": "^6.1.4",
+                "nuxt-site-config": "^3.2.5",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
+                "pkg-types": "^2.3.0",
+                "sirv": "^3.0.2"
             },
-            "engines": {
-                "node": ">=18.12.0"
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "@unhead/vue": "^2.0.7",
+                "unhead": "^2.0.7"
+            },
+            "peerDependenciesMeta": {
+                "@unhead/vue": {
+                    "optional": true
+                },
+                "unhead": {
+                    "optional": true
+                }
             }
         },
         "node_modules/nuxt-seo-utils": {
-            "version": "7.0.14",
-            "resolved": "https://registry.npmjs.org/nuxt-seo-utils/-/nuxt-seo-utils-7.0.14.tgz",
-            "integrity": "sha512-SvUCHWhnt8U/nKIpmnbe3lIvv6GewqxbxkLvcU6R7TeEIHoPnBtNLPN+nKOj12fMrDThv178/RAfw7KXq6meiw==",
+            "version": "7.0.17",
+            "resolved": "https://registry.npmjs.org/nuxt-seo-utils/-/nuxt-seo-utils-7.0.17.tgz",
+            "integrity": "sha512-YxzavD3RjDoKDfjuYufZ7gq2i8q9DpSXGFsWtHNXpk9Fi3NGnGJ0v4nHw3xxkmplXDoPkzn3Aijq59ryIcreIg==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^4.0.1",
-                "@unhead/addons": "^2.0.12",
+                "@nuxt/kit": "^4.1.2",
+                "@unhead/addons": "^2.0.14",
                 "defu": "^6.1.4",
                 "escape-string-regexp": "^5.0.0",
                 "fast-glob": "^3.3.3",
                 "image-size": "^2.0.2",
-                "nuxt-site-config": "^3.2.2",
+                "nuxt-site-config": "^3.2.8",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
+                "pkg-types": "^2.3.0",
                 "scule": "^1.3.0",
                 "semver": "^7.7.2",
                 "ufo": "^1.6.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
-            }
-        },
-        "node_modules/nuxt-seo-utils/node_modules/@nuxt/kit": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.0.3.tgz",
-            "integrity": "sha512-9+lwvP4n8KhO91azoebO0o39smESGzEV4HU6nef9HIFyt04YwlVMY37Pk63GgZn0WhWVjyPWcQWs0rUdZUYcPw==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
             }
         },
         "node_modules/nuxt-seo-utils/node_modules/escape-string-regexp": {
@@ -13829,83 +13684,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nuxt-seo-utils/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/nuxt-seo-utils/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/nuxt-seo-utils/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
         "node_modules/nuxt-site-config": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-3.2.2.tgz",
-            "integrity": "sha512-0zCo8nZKk11F4oEWvioTPpxYesJtiwWGfanh1coOfPmvGdYuCcJ/pusy8zdPb6xQkvAYqpTZUy7KKfjXjrE8rA==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-3.2.8.tgz",
+            "integrity": "sha512-mmxqqh1abQ6ObNdK0OsvbYr5i/35RYAN3638CAUxTG1cJkihhj5CSGAcdSb4XjjqW6PFsVTT9LW4M/g2jrOXmw==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^3.17.5",
-                "nuxt-site-config-kit": "3.2.2",
+                "@nuxt/kit": "^4.1.2",
+                "nuxt-site-config-kit": "3.2.8",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.1.0",
-                "sirv": "^3.0.1",
-                "site-config-stack": "3.2.2",
+                "pkg-types": "^2.3.0",
+                "sirv": "^3.0.2",
+                "site-config-stack": "3.2.8",
                 "ufo": "^1.6.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "h3": "^1"
             }
         },
         "node_modules/nuxt-site-config-kit": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-3.2.2.tgz",
-            "integrity": "sha512-SmTBVm6JQd5zHBy04/qn0gWo3rg1HTRGT/H91hxk/o+mDB3ll+TkzpZekD46RUBO/AD02ArLG5n2ndu6zhWsHA==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-3.2.8.tgz",
+            "integrity": "sha512-g6h+PDgvZOmFbTZyvz4CozicUtepBIe7bwS+tklPfaCvbuy6XPXvl+dkMO54VamCOj+9d5190HMHe+ZpQEyZFA==",
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "^3.17.5",
-                "pkg-types": "^2.1.0",
-                "site-config-stack": "3.2.2",
+                "@nuxt/kit": "^4.1.2",
+                "pkg-types": "^2.3.0",
+                "site-config-stack": "3.2.8",
                 "std-env": "^3.9.0",
                 "ufo": "^1.6.1"
             },
@@ -13913,10 +13721,10 @@
                 "url": "https://github.com/sponsors/harlan-zw"
             }
         },
-        "node_modules/nuxt-site-config-kit/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
+        "node_modules/nuxt/node_modules/@nuxt/kit": {
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
+            "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
             "license": "MIT",
             "dependencies": {
                 "c12": "^3.2.0",
@@ -13929,175 +13737,19 @@
                 "jiti": "^2.5.1",
                 "klona": "^2.0.6",
                 "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
+                "mlly": "^1.8.0",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2",
                 "scule": "^1.3.0",
                 "semver": "^7.7.2",
                 "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
+                "tinyglobby": "^0.2.15",
                 "ufo": "^1.6.1",
                 "unctx": "^2.4.1",
                 "unimport": "^5.2.0",
                 "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/nuxt-site-config-kit/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-site-config-kit/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/nuxt-site-config-kit/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/nuxt-site-config-kit/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/nuxt-site-config/node_modules/@nuxt/kit": {
-            "version": "3.18.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.18.1.tgz",
-            "integrity": "sha512-z6w1Fzv27CIKFlhct05rndkJSfoslplWH5fJ9dtusEvpYScLXp5cATWIbWkte9e9zFSmQTgDQJjNs3geQHE7og==",
-            "license": "MIT",
-            "dependencies": {
-                "c12": "^3.2.0",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "destr": "^2.0.5",
-                "errx": "^0.1.0",
-                "exsolve": "^1.0.7",
-                "ignore": "^7.0.5",
-                "jiti": "^2.5.1",
-                "klona": "^2.0.6",
-                "knitwork": "^1.2.0",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.11",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "semver": "^7.7.2",
-                "std-env": "^3.9.0",
-                "tinyglobby": "^0.2.14",
-                "ufo": "^1.6.1",
-                "unctx": "^2.4.1",
-                "unimport": "^5.2.0",
-                "untyped": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            }
-        },
-        "node_modules/nuxt-site-config/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/nuxt-site-config/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/nuxt-site-config/node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/nuxt-site-config/node_modules/unimport": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
-            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.15.0",
-                "escape-string-regexp": "^5.0.0",
-                "estree-walker": "^3.0.3",
-                "local-pkg": "^1.1.1",
-                "magic-string": "^0.30.17",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "pkg-types": "^2.2.0",
-                "scule": "^1.3.0",
-                "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.14",
-                "unplugin": "^2.3.5",
-                "unplugin-utils": "^0.2.4"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -14131,16 +13783,16 @@
             }
         },
         "node_modules/nypm": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.0.tgz",
-            "integrity": "sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
+            "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
-                "consola": "^3.4.0",
+                "consola": "^3.4.2",
                 "pathe": "^2.0.3",
-                "pkg-types": "^2.0.0",
-                "tinyexec": "^0.3.2"
+                "pkg-types": "^2.3.0",
+                "tinyexec": "^1.0.1"
             },
             "bin": {
                 "nypm": "dist/cli.mjs"
@@ -14258,47 +13910,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/openapi-typescript": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.6.1.tgz",
-            "integrity": "sha512-F7RXEeo/heF3O9lOXo2bNjCOtfp7u+D6W3a3VNEH2xE6v+fxLtn5nq0uvUcA1F5aT+CMhNeC5Uqtg5tlXFX/ag==",
-            "license": "MIT",
-            "dependencies": {
-                "@redocly/openapi-core": "^1.28.0",
-                "ansi-colors": "^4.1.3",
-                "change-case": "^5.4.4",
-                "parse-json": "^8.1.0",
-                "supports-color": "^9.4.0",
-                "yargs-parser": "^21.1.1"
-            },
-            "bin": {
-                "openapi-typescript": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "typescript": "^5.x"
-            }
-        },
-        "node_modules/openapi-typescript/node_modules/supports-color": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-            "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/openapi-typescript/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -14316,14 +13927,11 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/oxc-parser": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.56.5.tgz",
-            "integrity": "sha512-MNT32sqiTFeSbQZP2WZIRQ/mlIpNNq4sua+/4hBG4qT5aef2iQe+1/BjezZURPlvucZeSfN1Y6b60l7OgBdyUA==",
+        "node_modules/oxc-minify": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.87.0.tgz",
+            "integrity": "sha512-+UHWp6+0mdq0S2rEsZx9mqgL6JnG9ogO+CU17XccVrPUFtISFcZzk/biTn1JdBYFQ3kztof19pv8blMtgStQ2g==",
             "license": "MIT",
-            "dependencies": {
-                "@oxc-project/types": "^0.56.5"
-            },
             "engines": {
                 "node": ">=14.0.0"
             },
@@ -14331,25 +13939,94 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-darwin-arm64": "0.56.5",
-                "@oxc-parser/binding-darwin-x64": "0.56.5",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.56.5",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.56.5",
-                "@oxc-parser/binding-linux-arm64-musl": "0.56.5",
-                "@oxc-parser/binding-linux-x64-gnu": "0.56.5",
-                "@oxc-parser/binding-linux-x64-musl": "0.56.5",
-                "@oxc-parser/binding-wasm32-wasi": "0.56.5",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.56.5",
-                "@oxc-parser/binding-win32-x64-msvc": "0.56.5"
+                "@oxc-minify/binding-android-arm64": "0.87.0",
+                "@oxc-minify/binding-darwin-arm64": "0.87.0",
+                "@oxc-minify/binding-darwin-x64": "0.87.0",
+                "@oxc-minify/binding-freebsd-x64": "0.87.0",
+                "@oxc-minify/binding-linux-arm-gnueabihf": "0.87.0",
+                "@oxc-minify/binding-linux-arm-musleabihf": "0.87.0",
+                "@oxc-minify/binding-linux-arm64-gnu": "0.87.0",
+                "@oxc-minify/binding-linux-arm64-musl": "0.87.0",
+                "@oxc-minify/binding-linux-riscv64-gnu": "0.87.0",
+                "@oxc-minify/binding-linux-s390x-gnu": "0.87.0",
+                "@oxc-minify/binding-linux-x64-gnu": "0.87.0",
+                "@oxc-minify/binding-linux-x64-musl": "0.87.0",
+                "@oxc-minify/binding-wasm32-wasi": "0.87.0",
+                "@oxc-minify/binding-win32-arm64-msvc": "0.87.0",
+                "@oxc-minify/binding-win32-x64-msvc": "0.87.0"
             }
         },
-        "node_modules/oxc-parser/node_modules/@oxc-project/types": {
-            "version": "0.56.5",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.56.5.tgz",
-            "integrity": "sha512-skY3kOJwp22W4RkaadH1hZ3hqFHjkRrIIE0uQ4VUg+/Chvbl+2pF+B55IrIk2dgsKXS57YEUsJuN6I6s4rgFjA==",
+        "node_modules/oxc-parser": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.87.0.tgz",
+            "integrity": "sha512-uc47XrtHwkBoES4HFgwgfH9sqwAtJXgAIBq4fFBMZ4hWmgVZoExyn+L4g4VuaecVKXkz1bvlaHcfwHAJPQb5Gw==",
             "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "^0.87.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm64": "0.87.0",
+                "@oxc-parser/binding-darwin-arm64": "0.87.0",
+                "@oxc-parser/binding-darwin-x64": "0.87.0",
+                "@oxc-parser/binding-freebsd-x64": "0.87.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.87.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.87.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.87.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.87.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.87.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.87.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.87.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.87.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.87.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.87.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.87.0"
+            }
+        },
+        "node_modules/oxc-transform": {
+            "version": "0.87.0",
+            "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.87.0.tgz",
+            "integrity": "sha512-dt6INKWY2DKbSc8yR9VQoqBsCjPQ3z/SKv882UqlwFve+K38xtpi2avDlvNd35SpHUwDLDFoV3hMX0U3qOSaaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-transform/binding-android-arm64": "0.87.0",
+                "@oxc-transform/binding-darwin-arm64": "0.87.0",
+                "@oxc-transform/binding-darwin-x64": "0.87.0",
+                "@oxc-transform/binding-freebsd-x64": "0.87.0",
+                "@oxc-transform/binding-linux-arm-gnueabihf": "0.87.0",
+                "@oxc-transform/binding-linux-arm-musleabihf": "0.87.0",
+                "@oxc-transform/binding-linux-arm64-gnu": "0.87.0",
+                "@oxc-transform/binding-linux-arm64-musl": "0.87.0",
+                "@oxc-transform/binding-linux-riscv64-gnu": "0.87.0",
+                "@oxc-transform/binding-linux-s390x-gnu": "0.87.0",
+                "@oxc-transform/binding-linux-x64-gnu": "0.87.0",
+                "@oxc-transform/binding-linux-x64-musl": "0.87.0",
+                "@oxc-transform/binding-wasm32-wasi": "0.87.0",
+                "@oxc-transform/binding-win32-arm64-msvc": "0.87.0",
+                "@oxc-transform/binding-win32-x64-msvc": "0.87.0"
+            }
+        },
+        "node_modules/oxc-walker": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-0.5.2.tgz",
+            "integrity": "sha512-XYoZqWwApSKUmSDEFeOKdy3Cdh95cOcSU8f7yskFWE4Rl3cfL5uwyY+EV7Brk9mdNLy+t5SseJajd6g7KncvlA==",
+            "license": "MIT",
+            "dependencies": {
+                "magic-regexp": "^0.10.0"
+            },
+            "peerDependencies": {
+                "oxc-parser": ">=0.72.0"
             }
         },
         "node_modules/p-cancelable": {
@@ -14501,17 +14178,18 @@
             }
         },
         "node_modules/parse-json": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.2.0.tgz",
-            "integrity": "sha512-eONBZy4hm2AgxjNFd8a4nyDJnzUAH0g34xSQAwWEVGCjdZ4ZL7dKZBfq267GWP/JaS9zW62Xs2FeAdDvpHHJGQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "index-to-position": "^1.0.0",
-                "type-fest": "^4.37.0"
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14530,9 +14208,9 @@
             }
         },
         "node_modules/parse-path": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.1.tgz",
-            "integrity": "sha512-6ReLMptznuuOEzLoGEa+I1oWRSj2Zna5jLWC+l6zlfAI4dbbSaIES29ThzuPkbhNahT65dWzfoZEO6cfJw2Ksg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+            "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
             "license": "MIT",
             "dependencies": {
                 "protocols": "^2.0.0"
@@ -14570,7 +14248,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/path-exists": {
@@ -14667,9 +14344,9 @@
             }
         },
         "node_modules/perfect-debounce": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
+            "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -14735,9 +14412,9 @@
             }
         },
         "node_modules/pirates": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-            "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14755,16 +14432,10 @@
                 "pathe": "^2.0.3"
             }
         },
-        "node_modules/pkg-types/node_modules/confbox": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT"
-        },
         "node_modules/playwright-core": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-            "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+            "version": "1.55.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+            "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -14792,9 +14463,9 @@
             }
         },
         "node_modules/portfinder": {
-            "version": "1.0.35",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.35.tgz",
-            "integrity": "sha512-73JaFg4NwYNAufDtS5FsFu/PdM49ahJrO1i44aCRsDWju1z5wuGDaqyFUQWR6aJoK2JPDWlaYYAGFNIGTSUHSw==",
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+            "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14863,12 +14534,12 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
-            "integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.4.tgz",
+            "integrity": "sha512-ziQuVzQZBROpKpfeDwmrG+Vvlr0YWmY/ZAk99XD+mGEBuEojoFekL41NCsdhyNUtZI7DPOoIWIR7vQQK9xwluw==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "caniuse-api": "^3.0.0",
                 "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
@@ -14877,74 +14548,87 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.4.tgz",
-            "integrity": "sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.7.tgz",
+            "integrity": "sha512-HR9DZLN04Xbe6xugRH6lS4ZQH2zm/bFh/ZyRkpedZozhvh+awAfbA0P36InO4fZfDhvYfNJeNvlTf1sjwGbw/A==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.3.tgz",
-            "integrity": "sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.4.tgz",
+            "integrity": "sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==",
             "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^6.1.2"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-discard-comments/node_modules/postcss-selector-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/postcss-discard-duplicates": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
-            "integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
+            "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
             "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-discard-empty": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.0.tgz",
-            "integrity": "sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
+            "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-discard-overridden": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.0.tgz",
-            "integrity": "sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
+            "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-import": {
@@ -14966,20 +14650,26 @@
             }
         },
         "node_modules/postcss-js": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-            "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+            "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "camelcase-css": "^2.0.1"
             },
             "engines": {
                 "node": "^12 || ^14 || >= 16"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
             },
             "peerDependencies": {
                 "postcss": "^8.4.21"
@@ -15022,102 +14712,128 @@
             }
         },
         "node_modules/postcss-merge-longhand": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.4.tgz",
-            "integrity": "sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
+            "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^7.0.4"
+                "stylehacks": "^7.0.5"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.4.tgz",
-            "integrity": "sha512-ZsaamiMVu7uBYsIdGtKJ64PkcQt6Pcpep/uO90EpLS3dxJi6OXamIobTYcImyXGoW0Wpugh7DSD3XzxZS9JCPg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.6.tgz",
+            "integrity": "sha512-2jIPT4Tzs8K87tvgCpSukRQ2jjd+hH6Bb8rEEOUDmmhOeTcqDg5fEFK8uKIu+Pvc3//sm3Uu6FRqfyv7YF7+BQ==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^5.0.0",
-                "postcss-selector-parser": "^6.1.2"
+                "cssnano-utils": "^5.0.1",
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
-        "node_modules/postcss-minify-font-values": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.0.tgz",
-            "integrity": "sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==",
-            "license": "MIT",
-            "dependencies": {
-                "postcss-value-parser": "^4.2.0"
-            },
-            "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.4.31"
-            }
-        },
-        "node_modules/postcss-minify-gradients": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.0.tgz",
-            "integrity": "sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==",
-            "license": "MIT",
-            "dependencies": {
-                "colord": "^2.9.3",
-                "cssnano-utils": "^5.0.0",
-                "postcss-value-parser": "^4.2.0"
-            },
-            "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.4.31"
-            }
-        },
-        "node_modules/postcss-minify-params": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
-            "integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
-            "license": "MIT",
-            "dependencies": {
-                "browserslist": "^4.23.3",
-                "cssnano-utils": "^5.0.0",
-                "postcss-value-parser": "^4.2.0"
-            },
-            "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.4.31"
-            }
-        },
-        "node_modules/postcss-minify-selectors": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.4.tgz",
-            "integrity": "sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==",
+        "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "postcss-selector-parser": "^6.1.2"
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postcss-minify-font-values": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
+            "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-minify-gradients": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
+            "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
+            "license": "MIT",
+            "dependencies": {
+                "colord": "^2.9.3",
+                "cssnano-utils": "^5.0.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-minify-params": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.4.tgz",
+            "integrity": "sha512-3OqqUddfH8c2e7M35W6zIwv7jssM/3miF9cbCSb1iJiWvtguQjlxZGIHK9JRmc8XAKmE2PFGtHSM7g/VcW97sw==",
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.25.1",
+                "cssnano-utils": "^5.0.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-minify-selectors": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
+            "integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "postcss-selector-parser": "^7.1.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/postcss-nested": {
@@ -15147,9 +14863,9 @@
             }
         },
         "node_modules/postcss-nesting": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-            "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+            "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
             "dev": true,
             "funding": [
                 {
@@ -15163,7 +14879,7 @@
             ],
             "license": "MIT-0",
             "dependencies": {
-                "@csstools/selector-resolve-nested": "^3.0.0",
+                "@csstools/selector-resolve-nested": "^3.1.0",
                 "@csstools/selector-specificity": "^5.0.0",
                 "postcss-selector-parser": "^7.0.0"
             },
@@ -15175,9 +14891,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-            "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+            "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
             "dev": true,
             "funding": [
                 {
@@ -15235,21 +14951,21 @@
             }
         },
         "node_modules/postcss-normalize-charset": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.0.tgz",
-            "integrity": "sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
+            "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
             "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-display-values": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.0.tgz",
-            "integrity": "sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
+            "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15258,13 +14974,13 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-positions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.0.tgz",
-            "integrity": "sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
+            "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15273,13 +14989,13 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-repeat-style": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.0.tgz",
-            "integrity": "sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
+            "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15288,13 +15004,13 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-string": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.0.tgz",
-            "integrity": "sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
+            "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15303,13 +15019,13 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-timing-functions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.0.tgz",
-            "integrity": "sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
+            "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15318,29 +15034,29 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
-            "integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.4.tgz",
+            "integrity": "sha512-LvIURTi1sQoZqj8mEIE8R15yvM+OhbR1avynMtI9bUzj5gGKR/gfZFd8O7VMj0QgJaIFzxDwxGl/ASMYAkqO8g==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-url": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.0.tgz",
-            "integrity": "sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
+            "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15349,13 +15065,13 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-normalize-whitespace": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.0.tgz",
-            "integrity": "sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
+            "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15364,45 +15080,45 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-ordered-values": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.1.tgz",
-            "integrity": "sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
+            "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
             "license": "MIT",
             "dependencies": {
-                "cssnano-utils": "^5.0.0",
+                "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
-            "integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.4.tgz",
+            "integrity": "sha512-rdIC9IlMBn7zJo6puim58Xd++0HdbvHeHaPgXsimMfG1ijC5A9ULvNLSE0rUKVJOvNMcwewW4Ga21ngyJjY/+Q==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
+                "browserslist": "^4.25.1",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-reduce-transforms": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.0.tgz",
-            "integrity": "sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
+            "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -15411,7 +15127,7 @@
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
             }
         },
         "node_modules/postcss-selector-parser": {
@@ -15428,34 +15144,100 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.1.tgz",
-            "integrity": "sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.0.tgz",
+            "integrity": "sha512-KnAlfmhtoLz6IuU3Sij2ycusNs4jPW+QoFE5kuuUOK8awR6tMxZQrs5Ey3BUz7nFCzT3eqyFgqkyrHiaU2xx3w==",
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^3.3.2"
+                "svgo": "^4.0.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >= 18"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-svgo/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/postcss-svgo/node_modules/css-tree": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.12.2",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/postcss-svgo/node_modules/mdn-data": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "license": "CC0-1.0"
+        },
+        "node_modules/postcss-svgo/node_modules/svgo": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+            "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^11.1.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^3.0.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.1.1",
+                "sax": "^1.4.1"
+            },
+            "bin": {
+                "svgo": "bin/svgo.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.3.tgz",
-            "integrity": "sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
+            "integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
             "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^6.1.2"
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/postcss-value-parser": {
@@ -15465,9 +15247,9 @@
             "license": "MIT"
         },
         "node_modules/potpack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-            "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+            "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
             "license": "ISC"
         },
         "node_modules/preact": {
@@ -15515,9 +15297,9 @@
             "optional": true
         },
         "node_modules/prebuild-install/node_modules/detect-libc": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+            "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
@@ -15540,9 +15322,9 @@
             }
         },
         "node_modules/prebuild-install/node_modules/tar-fs": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+            "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -15694,9 +15476,9 @@
             }
         },
         "node_modules/pretty-ms": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
-            "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+            "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
             "license": "MIT",
             "dependencies": {
                 "parse-ms": "^4.0.0"
@@ -15803,9 +15585,9 @@
             "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-            "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -15872,12 +15654,6 @@
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^6.2.0"
             }
-        },
-        "node_modules/qrcode/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
         },
         "node_modules/qrcode/node_modules/find-up": {
             "version": "4.1.0",
@@ -16031,9 +15807,9 @@
             }
         },
         "node_modules/quansync": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-            "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+            "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
             "funding": [
                 {
                     "type": "individual",
@@ -16167,6 +15943,21 @@
                 "pify": "^2.3.0"
             }
         },
+        "node_modules/read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/read-pkg-up": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
@@ -16197,12 +15988,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/read-pkg-up/node_modules/hosted-git-info": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "license": "ISC"
-        },
         "node_modules/read-pkg-up/node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -16213,18 +15998,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
             }
         },
         "node_modules/read-pkg-up/node_modules/p-limit": {
@@ -16254,24 +16027,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/read-pkg-up/node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/read-pkg-up/node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -16281,31 +16036,34 @@
                 "node": ">=8"
             }
         },
-        "node_modules/read-pkg-up/node_modules/read-pkg": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^2.5.0",
-                "parse-json": "^5.0.0",
-                "type-fest": "^0.6.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+        "node_modules/read-pkg-up/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/read-pkg-up/node_modules/semver": {
+        "node_modules/read-pkg/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "license": "ISC"
+        },
+        "node_modules/read-pkg/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/read-pkg/node_modules/semver": {
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
@@ -16314,10 +16072,10 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
@@ -16604,15 +16362,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -16812,21 +16561,6 @@
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "license": "MIT"
         },
-        "node_modules/rimraf": {
-            "version": "5.0.10",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^10.3.7"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/robust-predicates": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
@@ -16834,12 +16568,12 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.37.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
-            "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+            "version": "4.50.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+            "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.6"
+                "@types/estree": "1.0.8"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -16849,36 +16583,37 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.37.0",
-                "@rollup/rollup-android-arm64": "4.37.0",
-                "@rollup/rollup-darwin-arm64": "4.37.0",
-                "@rollup/rollup-darwin-x64": "4.37.0",
-                "@rollup/rollup-freebsd-arm64": "4.37.0",
-                "@rollup/rollup-freebsd-x64": "4.37.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.37.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.37.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.37.0",
-                "@rollup/rollup-linux-arm64-musl": "4.37.0",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.37.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.37.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.37.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.37.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.37.0",
-                "@rollup/rollup-linux-x64-gnu": "4.37.0",
-                "@rollup/rollup-linux-x64-musl": "4.37.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.37.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.37.0",
-                "@rollup/rollup-win32-x64-msvc": "4.37.0",
+                "@rollup/rollup-android-arm-eabi": "4.50.2",
+                "@rollup/rollup-android-arm64": "4.50.2",
+                "@rollup/rollup-darwin-arm64": "4.50.2",
+                "@rollup/rollup-darwin-x64": "4.50.2",
+                "@rollup/rollup-freebsd-arm64": "4.50.2",
+                "@rollup/rollup-freebsd-x64": "4.50.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+                "@rollup/rollup-linux-arm64-musl": "4.50.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+                "@rollup/rollup-linux-x64-gnu": "4.50.2",
+                "@rollup/rollup-linux-x64-musl": "4.50.2",
+                "@rollup/rollup-openharmony-arm64": "4.50.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+                "@rollup/rollup-win32-x64-msvc": "4.50.2",
                 "fsevents": "~2.3.2"
             }
         },
         "node_modules/rollup-plugin-visualizer": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
-            "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.3.tgz",
+            "integrity": "sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==",
             "license": "MIT",
             "dependencies": {
-                "open": "^8.4.0",
+                "open": "^8.0.0",
                 "picomatch": "^4.0.2",
                 "source-map": "^0.7.4",
                 "yargs": "^17.5.1"
@@ -16890,7 +16625,7 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "rolldown": "1.x",
+                "rolldown": "1.x || ^1.0.0-beta",
                 "rollup": "2.x || 3.x || 4.x"
             },
             "peerDependenciesMeta": {
@@ -16955,16 +16690,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/rollup/node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-            "license": "MIT"
-        },
         "node_modules/run-applescript": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -17060,6 +16789,12 @@
                 "ultrahtml": "^1.2.0"
             }
         },
+        "node_modules/sax": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+            "license": "ISC"
+        },
         "node_modules/scslre": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
@@ -17093,63 +16828,46 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "debug": "^4.3.5",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "mime-types": "^3.0.1",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
             }
         },
-        "node_modules/send/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "node_modules/send/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/send/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
             "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/send/node_modules/debug/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "license": "MIT"
-        },
-        "node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/send/node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
+                "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">= 0.6"
             }
         },
         "node_modules/serialize-javascript": {
@@ -17180,18 +16898,18 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
             }
         },
         "node_modules/set-blocking": {
@@ -17243,9 +16961,9 @@
             }
         },
         "node_modules/sharp/node_modules/detect-libc": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+            "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
@@ -17352,14 +17070,14 @@
             }
         },
         "node_modules/simple-git": {
-            "version": "3.27.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
-            "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+            "version": "3.28.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+            "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
             "license": "MIT",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
-                "debug": "^4.3.5"
+                "debug": "^4.4.0"
             },
             "funding": {
                 "type": "github",
@@ -17367,19 +17085,26 @@
             }
         },
         "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+            "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "is-arrayish": "^0.3.1"
             }
         },
+        "node_modules/simple-swizzle/node_modules/is-arrayish": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+            "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/sirv": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
-            "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
             "license": "MIT",
             "dependencies": {
                 "@polka/url": "^1.0.0-next.24",
@@ -17397,9 +17122,9 @@
             "license": "MIT"
         },
         "node_modules/site-config-stack": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-3.2.2.tgz",
-            "integrity": "sha512-T1NphPh1sWlsIXbD1q1HDgHbX40miTyi++cDqXkVOuHQ/eQnGp6w8cwB8u9XmgSZsnmZpsQJgPUTNH7SX173AA==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-3.2.8.tgz",
+            "integrity": "sha512-MZ55OBRmsuPT0P1D9HkTduchRsSGlWz+WiCDKmELO4FTxB+nuscHLrPAbS8bL2aEFlj/vDH8+bdTDezI4k7kXQ==",
             "license": "MIT",
             "dependencies": {
                 "ufo": "^1.6.1"
@@ -17424,17 +17149,17 @@
             }
         },
         "node_modules/slice-ansi": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.0.0",
-                "is-fullwidth-code-point": "^4.0.0"
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -17447,12 +17172,12 @@
             "license": "MIT"
         },
         "node_modules/source-map": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
             "license": "BSD-3-Clause",
             "engines": {
-                "node": ">= 8"
+                "node": ">= 12"
             }
         },
         "node_modules/source-map-js": {
@@ -17520,9 +17245,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.21",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "version": "3.0.22",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
             "license": "CC0-1.0"
         },
         "node_modules/speakingurl": {
@@ -17556,9 +17281,9 @@
             "license": "MIT"
         },
         "node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -17571,9 +17296,9 @@
             "license": "MIT"
         },
         "node_modules/streamx": {
-            "version": "2.22.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-            "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
             "license": "MIT",
             "dependencies": {
                 "fast-fifo": "^1.3.2",
@@ -17603,18 +17328,17 @@
             }
         },
         "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+            "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
+                "get-east-asian-width": "^1.3.0",
                 "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -17644,12 +17368,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
-        },
         "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -17678,9 +17396,9 @@
             "license": "MIT"
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -17727,13 +17445,10 @@
             }
         },
         "node_modules/strip-indent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-            "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.0.tgz",
+            "integrity": "sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==",
             "license": "MIT",
-            "dependencies": {
-                "min-indent": "^1.0.1"
-            },
             "engines": {
                 "node": ">=12"
             },
@@ -17790,19 +17505,32 @@
             "license": "ISC"
         },
         "node_modules/stylehacks": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.4.tgz",
-            "integrity": "sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.6.tgz",
+            "integrity": "sha512-iitguKivmsueOmTO0wmxURXBP8uqOO+zikLGZ7Mm9e/94R4w5T999Js2taS/KBOnQ/wdC3jN3vNSrkGDrlnqQg==",
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3",
-                "postcss-selector-parser": "^6.1.2"
+                "browserslist": "^4.25.1",
+                "postcss-selector-parser": "^7.1.0"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
             "peerDependencies": {
-                "postcss": "^8.4.31"
+                "postcss": "^8.4.32"
+            }
+        },
+        "node_modules/stylehacks/node_modules/postcss-selector-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/subtag": {
@@ -17907,6 +17635,7 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
             "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
@@ -17932,6 +17661,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -18150,12 +17880,16 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
+            "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/tar": {
@@ -18176,9 +17910,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+            "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -18211,13 +17945,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-            "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+            "version": "5.44.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+            "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
+                "acorn": "^8.15.0",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -18285,19 +18019,19 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.3",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -18463,9 +18197,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.38.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-            "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
@@ -18487,6 +18221,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/type-level-regexp": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.17.tgz",
+            "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
+            "license": "MIT"
         },
         "node_modules/typescript": {
             "version": "5.9.2",
@@ -18541,22 +18281,22 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+            "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
             "license": "MIT"
         },
         "node_modules/unenv": {
-            "version": "2.0.0-rc.15",
-            "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
-            "integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
+            "version": "2.0.0-rc.21",
+            "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
+            "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.4",
-                "exsolve": "^1.0.4",
+                "exsolve": "^1.0.7",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "ufo": "^1.5.4"
+                "ufo": "^1.6.1"
             }
         },
         "node_modules/unhead": {
@@ -18600,24 +18340,24 @@
             }
         },
         "node_modules/unimport": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-4.1.3.tgz",
-            "integrity": "sha512-H+IVJ7rAkE3b+oC8rSJ2FsPaVsweeMC8eKZc+C6Mz7+hxDF45AnrY/tVCNRBvzMwWNcJEV67WdAVcal27iMjOw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
+            "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
             "license": "MIT",
             "dependencies": {
-                "acorn": "^8.14.1",
+                "acorn": "^8.15.0",
                 "escape-string-regexp": "^5.0.0",
                 "estree-walker": "^3.0.3",
                 "local-pkg": "^1.1.1",
                 "magic-string": "^0.30.17",
                 "mlly": "^1.7.4",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.2",
-                "pkg-types": "^2.1.0",
+                "picomatch": "^4.0.3",
+                "pkg-types": "^2.2.0",
                 "scule": "^1.3.0",
                 "strip-literal": "^3.0.0",
-                "tinyglobby": "^0.2.12",
-                "unplugin": "^2.2.2",
+                "tinyglobby": "^0.2.14",
+                "unplugin": "^2.3.5",
                 "unplugin-utils": "^0.2.4"
             },
             "engines": {
@@ -18656,9 +18396,9 @@
             }
         },
         "node_modules/unplugin": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.6.tgz",
-            "integrity": "sha512-+/MdXl8bLTXI2lJF22gUBeCFqZruEpL/oM9f8wxCuKh9+Mw9qeul3gTqgbKpMeOFlusCzc0s7x2Kax2xKW+FQg==",
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.10.tgz",
+            "integrity": "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
@@ -18688,45 +18428,14 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
-        "node_modules/unplugin-ast/node_modules/ast-kit": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
-            "integrity": "sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.28.0",
-                "pathe": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=20.18.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sxzz"
-            }
-        },
-        "node_modules/unplugin-ast/node_modules/magic-string-ast": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.2.tgz",
-            "integrity": "sha512-8ngQgLhcT0t3YBdn9CGkZqCYlvwW9pm7aWJwd7AxseVWf1RU8ZHCQvG1mt3N5vvUme+pXTcHB8G/7fE666U8Vw==",
-            "license": "MIT",
-            "dependencies": {
-                "magic-string": "^0.30.17"
-            },
-            "engines": {
-                "node": ">=20.18.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sxzz"
-            }
-        },
         "node_modules/unplugin-utils": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
-            "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+            "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
             "license": "MIT",
             "dependencies": {
-                "pathe": "^2.0.2",
-                "picomatch": "^4.0.2"
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -18736,29 +18445,31 @@
             }
         },
         "node_modules/unplugin-vue-router": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/unplugin-vue-router/-/unplugin-vue-router-0.12.0.tgz",
-            "integrity": "sha512-xjgheKU0MegvXQcy62GVea0LjyOdMxN0/QH+ijN29W62ZlMhG7o7K+0AYqfpprvPwpWtuRjiyC5jnV2SxWye2w==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/unplugin-vue-router/-/unplugin-vue-router-0.15.0.tgz",
+            "integrity": "sha512-PyGehCjd9Ny9h+Uer4McbBjjib3lHihcyUEILa7pHKl6+rh8N7sFyw4ZkV+N30Oq2zmIUG7iKs3qpL0r+gXAaQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.8",
-                "@vue-macros/common": "^1.16.1",
-                "ast-walker-scope": "^0.6.2",
+                "@vue-macros/common": "3.0.0-beta.16",
+                "@vue/language-core": "^3.0.1",
+                "ast-walker-scope": "^0.8.1",
                 "chokidar": "^4.0.3",
-                "fast-glob": "^3.3.3",
                 "json5": "^2.2.3",
-                "local-pkg": "^1.0.0",
+                "local-pkg": "^1.1.1",
                 "magic-string": "^0.30.17",
-                "micromatch": "^4.0.8",
                 "mlly": "^1.7.4",
-                "pathe": "^2.0.2",
+                "muggle-string": "^0.4.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
                 "scule": "^1.3.0",
-                "unplugin": "^2.2.0",
-                "unplugin-utils": "^0.2.3",
-                "yaml": "^2.7.0"
+                "tinyglobby": "^0.2.14",
+                "unplugin": "^2.3.5",
+                "unplugin-utils": "^0.2.4",
+                "yaml": "^2.8.0"
             },
             "peerDependencies": {
-                "vue-router": "^4.4.0"
+                "@vue/compiler-sfc": "^3.5.17",
+                "vue-router": "^4.5.1"
             },
             "peerDependenciesMeta": {
                 "vue-router": {
@@ -18801,17 +18512,17 @@
             }
         },
         "node_modules/unstorage": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.16.1.tgz",
-            "integrity": "sha512-gdpZ3guLDhz+zWIlYP1UwQ259tG5T5vYRzDaHMkQ1bBY1SQPutvZnrRjTFaWUUpseErJIgAZS51h6NOcZVZiqQ==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.1.tgz",
+            "integrity": "sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==",
             "license": "MIT",
             "dependencies": {
                 "anymatch": "^3.1.3",
                 "chokidar": "^4.0.3",
                 "destr": "^2.0.5",
-                "h3": "^1.15.3",
+                "h3": "^1.15.4",
                 "lru-cache": "^10.4.3",
-                "node-fetch-native": "^1.6.6",
+                "node-fetch-native": "^1.6.7",
                 "ofetch": "^1.4.1",
                 "ufo": "^1.6.1"
             },
@@ -18828,6 +18539,7 @@
                 "@planetscale/database": "^1.19.0",
                 "@upstash/redis": "^1.34.3",
                 "@vercel/blob": ">=0.27.1",
+                "@vercel/functions": "^2.2.12 || ^3.0.0",
                 "@vercel/kv": "^1.0.1",
                 "aws4fetch": "^1.0.20",
                 "db0": ">=0.2.1",
@@ -18870,6 +18582,9 @@
                     "optional": true
                 },
                 "@vercel/blob": {
+                    "optional": true
+                },
+                "@vercel/functions": {
                     "optional": true
                 },
                 "@vercel/kv": {
@@ -18935,53 +18650,17 @@
             }
         },
         "node_modules/unwasm": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.3.9.tgz",
-            "integrity": "sha512-LDxTx/2DkFURUd+BU1vUsF/moj0JsoTvl+2tcg2AUOiEzVturhGGx17/IMgGvKUYdZwr33EJHtChCJuhu9Ouvg==",
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.3.11.tgz",
+            "integrity": "sha512-Vhp5gb1tusSQw5of/g3Q697srYgMXvwMgXMjcG4ZNga02fDX9coxJ9fAb0Ci38hM2Hv/U1FXRPGgjP2BYqhNoQ==",
             "license": "MIT",
             "dependencies": {
-                "knitwork": "^1.0.0",
-                "magic-string": "^0.30.8",
-                "mlly": "^1.6.1",
-                "pathe": "^1.1.2",
-                "pkg-types": "^1.0.3",
-                "unplugin": "^1.10.0"
-            }
-        },
-        "node_modules/unwasm/node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-            "license": "MIT"
-        },
-        "node_modules/unwasm/node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
+                "knitwork": "^1.2.0",
+                "magic-string": "^0.30.17",
                 "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
-            }
-        },
-        "node_modules/unwasm/node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
-        },
-        "node_modules/unwasm/node_modules/unplugin": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
-            "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.2.0",
+                "unplugin": "^2.3.6"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -19028,12 +18707,6 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/uri-js-replace": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-            "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-            "license": "MIT"
         },
         "node_modules/url-parse": {
             "version": "1.5.10",
@@ -19108,23 +18781,23 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-            "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+            "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -19133,14 +18806,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"
@@ -19182,56 +18855,44 @@
             }
         },
         "node_modules/vite-dev-rpc": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/vite-dev-rpc/-/vite-dev-rpc-1.0.7.tgz",
-            "integrity": "sha512-FxSTEofDbUi2XXujCA+hdzCDkXFG1PXktMjSk1efq9Qb5lOYaaM9zNSvKvPPF7645Bak79kSp1PTooMW2wktcA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vite-dev-rpc/-/vite-dev-rpc-1.1.0.tgz",
+            "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
             "license": "MIT",
             "dependencies": {
-                "birpc": "^2.0.19",
-                "vite-hot-client": "^2.0.4"
+                "birpc": "^2.4.0",
+                "vite-hot-client": "^2.1.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             },
             "peerDependencies": {
-                "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1"
-            }
-        },
-        "node_modules/vite-dev-rpc/node_modules/vite-hot-client": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.0.4.tgz",
-            "integrity": "sha512-W9LOGAyGMrbGArYJN4LBCdOC5+Zwh7dHvOHC0KmGKkJhsOzaKbpo/jEjpPKVHIW0/jBWj8RZG0NUxfgA8BxgAg==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0"
+                "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0"
             }
         },
         "node_modules/vite-hot-client": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-0.2.4.tgz",
-            "integrity": "sha512-a1nzURqO7DDmnXqabFOliz908FRmIppkBKsJthS8rbe8hBEXwEwe4C3Pp33Z1JoFCYfVL4kTOMLKk0ZZxREIeA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.1.0.tgz",
+            "integrity": "sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             },
             "peerDependencies": {
-                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0"
+                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
             }
         },
         "node_modules/vite-node": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
-            "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.4.0",
-                "es-module-lexer": "^1.6.0",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
                 "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
@@ -19244,20 +18905,20 @@
             }
         },
         "node_modules/vite-plugin-inspect": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.0.0.tgz",
-            "integrity": "sha512-Q0RDNcMs1mbI2yGRwOzSapnnA6NFO0j88+Vb8pJX0iYMw34WczwKJi3JgheItDhbWRq/CLUR0cs+ajZpcUaIFQ==",
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.3.3.tgz",
+            "integrity": "sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==",
             "license": "MIT",
             "dependencies": {
-                "ansis": "^3.16.0",
-                "debug": "^4.4.0",
+                "ansis": "^4.1.0",
+                "debug": "^4.4.1",
                 "error-stack-parser-es": "^1.0.5",
-                "ohash": "^2.0.4",
-                "open": "^10.1.0",
-                "perfect-debounce": "^1.0.0",
+                "ohash": "^2.0.11",
+                "open": "^10.2.0",
+                "perfect-debounce": "^2.0.0",
                 "sirv": "^3.0.1",
-                "unplugin-utils": "^0.2.0",
-                "vite-dev-rpc": "^1.0.7"
+                "unplugin-utils": "^0.3.0",
+                "vite-dev-rpc": "^1.1.0"
             },
             "engines": {
                 "node": ">=14"
@@ -19266,7 +18927,7 @@
                 "url": "https://github.com/sponsors/antfu"
             },
             "peerDependencies": {
-                "vite": "^6.0.0"
+                "vite": "^6.0.0 || ^7.0.0-0"
             },
             "peerDependenciesMeta": {
                 "@nuxt/kit": {
@@ -19274,13 +18935,30 @@
                 }
             }
         },
+        "node_modules/vite-plugin-inspect/node_modules/unplugin-utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.0.tgz",
+            "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
+            "license": "MIT",
+            "dependencies": {
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
         "node_modules/vite-plugin-vue-tracer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-0.1.1.tgz",
-            "integrity": "sha512-8BuReHmbSPd6iRQDQhlyK5+DexY1Hmb4K0GUVo9Te1Yaz8gyOZspBm9qdG1SvebdSIKw3WNlzpdstJ47TJ4bOw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.0.0.tgz",
+            "integrity": "sha512-a+UB9IwGx5uwS4uG/a9kM6fCMnxONDkOTbgCUbhFpiGhqfxrrC1+9BibV7sWwUnwj1Dg6MnRxG0trLgUZslDXA==",
             "license": "MIT",
             "dependencies": {
                 "estree-walker": "^3.0.3",
+                "exsolve": "^1.0.7",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3",
                 "source-map-js": "^1.2.1"
@@ -19289,7 +18967,7 @@
                 "url": "https://github.com/sponsors/antfu"
             },
             "peerDependencies": {
-                "vite": "^6.0.0",
+                "vite": "^6.0.0 || ^7.0.0",
                 "vue": "^3.5.0"
             }
         },
@@ -19300,22 +18978,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/vite/node_modules/tinyglobby": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-            "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/vscode-uri": {
@@ -19354,12 +19016,12 @@
             }
         },
         "node_modules/vue-bundle-renderer": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-2.1.1.tgz",
-            "integrity": "sha512-+qALLI5cQncuetYOXp4yScwYvqh8c6SMXee3B+M7oTZxOgtESP0l4j/fXdEJoZ+EdMxkGWIj+aSEyjXkOdmd7g==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-2.1.2.tgz",
+            "integrity": "sha512-M4WRBO/O/7G9phGaGH9AOwOnYtY9ZpPoDVpBpRzR2jO5rFL9mgIlQIgums2ljCTC2HL1jDXFQc//CzWcAQHgAw==",
             "license": "MIT",
             "dependencies": {
-                "ufo": "^1.5.4"
+                "ufo": "^1.6.1"
             }
         },
         "node_modules/vue-devtools-stub": {
@@ -19416,7 +19078,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.7.tgz",
             "integrity": "sha512-BSMmW8GGEgHykrv7mRk6zfTdK+tw4MBZY/x6fFa7IkdXK3s/8hQRacPjG9/8YKFDIWGhBocwi6PlkQQ/93OgIQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.23",
@@ -19567,12 +19229,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
-        },
         "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -19606,6 +19262,31 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+            "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/wrappy": {
@@ -19719,12 +19400,6 @@
                 "node": ">= 14.6"
             }
         },
-        "node_modules/yaml-ast-parser": {
-            "version": "0.0.43",
-            "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-            "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
-            "license": "Apache-2.0"
-        },
         "node_modules/yargs": {
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -19760,12 +19435,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT"
         },
         "node_modules/yargs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -19834,9 +19503,9 @@
             }
         },
         "node_modules/yoctocolors": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-            "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -19852,31 +19521,26 @@
             "license": "MIT"
         },
         "node_modules/youch": {
-            "version": "4.1.0-beta.6",
-            "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.6.tgz",
-            "integrity": "sha512-y1aNsEeoLXnWb6pI9TvfNPIxySyo4Un3OGxKn7rsNj8+tgSquzXEWkzfA5y6gU0fvzmQgvx3JBn/p51qQ8Xg9A==",
+            "version": "4.1.0-beta.11",
+            "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.11.tgz",
+            "integrity": "sha512-sQi6PERyO/mT8w564ojOVeAlYTtVQmC2GaktQAf+IdI75/GKIggosBuvyVXvEV+FATAT6RbLdIjFoiIId4ozoQ==",
             "license": "MIT",
             "dependencies": {
-                "@poppinss/dumper": "^0.6.3",
+                "@poppinss/colors": "^4.1.5",
+                "@poppinss/dumper": "^0.6.4",
                 "@speed-highlight/core": "^1.2.7",
                 "cookie": "^1.0.2",
-                "youch-core": "^0.3.1"
-            },
-            "engines": {
-                "node": ">=18"
+                "youch-core": "^0.3.3"
             }
         },
         "node_modules/youch-core": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.2.tgz",
-            "integrity": "sha512-fusrlIMLeRvTFYLUjJ9KzlGC3N+6MOPJ68HNj/yJv2nz7zq8t4HEviLms2gkdRPUS7F5rZ5n+pYx9r88m6IE1g==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+            "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
             "license": "MIT",
             "dependencies": {
-                "@poppinss/exception": "^1.2.0",
+                "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/yup": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
         "@nuxt/image": "^1.11.0",
         "@nuxtjs/seo": "^3.1.0",
         "@pinia/nuxt": "^0.11.2",
-        "@studiometa/vue-mapbox-gl": "^2.7.2",
         "@tolgee/vue": "^6.2.7",
         "@uppy/core": "^5.0.1",
         "@uppy/dashboard": "^5.0.1",


### PR DESCRIPTION
fix: use native mapbox instead of vue-mapbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Activity pins now consistently show popups with details when clicked.
- Bug Fixes
  - Fixed duplicate pins appearing after activity updates.
  - Improved map cleanup to prevent residual maps when navigating away.
  - More reliable centering; uses a sensible default when coordinates are missing.
- Refactor
  - Reworked map rendering for better performance and stability while keeping existing controls and visuals.
- Chores
  - Removed an unused map dependency to reduce bundle size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->